### PR TITLE
Delegate on the fly

### DIFF
--- a/KS.Fiks.Maskinporten.Client.Tests/Cache/TokenCacheTests.cs
+++ b/KS.Fiks.Maskinporten.Client.Tests/Cache/TokenCacheTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading.Tasks;
 using FluentAssertions;
+using Ks.Fiks.Maskinporten.Client.Cache;
 using Xunit;
 
 namespace Ks.Fiks.Maskinporten.Client.Tests.Cache
@@ -21,7 +22,7 @@ namespace Ks.Fiks.Maskinporten.Client.Tests.Cache
 
             var expectedValue = _fixture.GetRandomToken();
 
-            var actualValue = await sut.GetToken("key", () => Task.FromResult(expectedValue)).ConfigureAwait(false);
+            var actualValue = await sut.GetToken(new TokenRequest { Scopes = "key"}, () => Task.FromResult(expectedValue)).ConfigureAwait(false);
 
             actualValue.Should().Be(expectedValue);
         }
@@ -34,9 +35,9 @@ namespace Ks.Fiks.Maskinporten.Client.Tests.Cache
             var expectedValue = _fixture.GetRandomToken(10);
             var otherValue = _fixture.GetRandomToken(10);
 
-            var firstValue = await sut.GetToken("key", () => Task.FromResult(expectedValue)).ConfigureAwait(false);
+            var firstValue = await sut.GetToken(new TokenRequest { Scopes = "key"}, () => Task.FromResult(expectedValue)).ConfigureAwait(false);
             await Task.Delay(TimeSpan.FromMilliseconds(100)).ConfigureAwait(false);
-            var secondValue = await sut.GetToken("key", () => Task.FromResult(otherValue)).ConfigureAwait(false);
+            var secondValue = await sut.GetToken(new TokenRequest { Scopes = "key"}, () => Task.FromResult(otherValue)).ConfigureAwait(false);
 
             secondValue.Should().Be(expectedValue);
         }
@@ -49,9 +50,9 @@ namespace Ks.Fiks.Maskinporten.Client.Tests.Cache
             var expectedValue = _fixture.GetRandomToken(1);
             var otherValue = _fixture.GetRandomToken(1);
 
-            var firstValue = await sut.GetToken("key", () => Task.FromResult(otherValue)).ConfigureAwait(false);
+            var firstValue = await sut.GetToken(new TokenRequest { Scopes = "key"}, () => Task.FromResult(otherValue)).ConfigureAwait(false);
             await Task.Delay(TimeSpan.FromMilliseconds(1500)).ConfigureAwait(false);
-            var secondValue = await sut.GetToken("key", () => Task.FromResult(expectedValue)).ConfigureAwait(false);
+            var secondValue = await sut.GetToken(new TokenRequest { Scopes = "key"}, () => Task.FromResult(expectedValue)).ConfigureAwait(false);
 
             secondValue.Should().Be(expectedValue);
         }

--- a/KS.Fiks.Maskinporten.Client/Cache/ITokenCache.cs
+++ b/KS.Fiks.Maskinporten.Client/Cache/ITokenCache.cs
@@ -5,6 +5,6 @@ namespace Ks.Fiks.Maskinporten.Client.Cache
 {
     public interface ITokenCache
     {
-        Task<MaskinportenToken> GetToken(string tokenKey, Func<Task<MaskinportenToken>> tokenGetter);
+        Task<MaskinportenToken> GetToken(TokenRequest tokenRequest, Func<Task<MaskinportenToken>> tokenGetter);
     }
 }

--- a/KS.Fiks.Maskinporten.Client/IMaskinportenClient.cs
+++ b/KS.Fiks.Maskinporten.Client/IMaskinportenClient.cs
@@ -8,5 +8,8 @@ namespace Ks.Fiks.Maskinporten.Client
         Task<MaskinportenToken> GetAccessToken(IEnumerable<string> scopes);
 
         Task<MaskinportenToken> GetAccessToken(string scopes);
+
+        Task<MaskinportenToken> GetDelegatedAccessToken(string consumerOrg, IEnumerable<string> scopes);
+        Task<MaskinportenToken> GetDelegatedAccessToken(string consumerOrg, string scopes);
     }
 }

--- a/KS.Fiks.Maskinporten.Client/MaskinportenClient.cs
+++ b/KS.Fiks.Maskinporten.Client/MaskinportenClient.cs
@@ -56,7 +56,7 @@ namespace Ks.Fiks.Maskinporten.Client
             return JsonConvert.DeserializeObject<MaskinportenResponse>(responseAsJson);
         }
 
-        private string ScopesAsString(IEnumerable<string> scopes)
+        private static string ScopesAsString(IEnumerable<string> scopes)
         {
             return string.Join(" ", scopes);
         }

--- a/KS.Fiks.Maskinporten.Client/TokenRequest.cs
+++ b/KS.Fiks.Maskinporten.Client/TokenRequest.cs
@@ -1,0 +1,36 @@
+using System;
+
+namespace Ks.Fiks.Maskinporten.Client.Cache
+{
+    public class TokenRequest
+    {
+        public string Scopes { get; set; }
+
+        public string ConsumerOrg { get; set; }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj))
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(this, obj))
+            {
+                return true;
+            }
+
+            return obj.GetType() == GetType() && Equals((TokenRequest) obj);
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(Scopes, ConsumerOrg);
+        }
+
+        private bool Equals(TokenRequest other)
+        {
+            return Scopes == other.Scopes && ConsumerOrg == other.ConsumerOrg;
+        }
+    }
+}


### PR DESCRIPTION
Støtter å spesifisere consumerOrg ved generering av token slik at man får cachet tokens der man har samme scopes og consumerOrg

Dette sørger også for at dotnet klienten har samme mulighet som Java