### PR TITLE
Support netstandard2 0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ bld/
 msbuild.log
 msbuild.err
 msbuild.wrn
+/.vs/
+/.cr/

--- a/KS.Fiks.Maskinporten.Client.Tests/KS.Fiks.Maskinporten.Client.Tests.csproj
+++ b/KS.Fiks.Maskinporten.Client.Tests/KS.Fiks.Maskinporten.Client.Tests.csproj
@@ -12,7 +12,7 @@
         <PackageReference Include="FluentAssertions" Version="5.10.3" />
         <PackageReference Include="KS.Fiks.QA" Version="1.0.0" PrivateAssets="All" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
-        <PackageReference Include="Moq" Version="4.14.5" />
+        <PackageReference Include="Moq" Version="4.14.7" />
         <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />

--- a/KS.Fiks.Maskinporten.Client/KS.Fiks.Maskinporten.Client.csproj
+++ b/KS.Fiks.Maskinporten.Client/KS.Fiks.Maskinporten.Client.csproj
@@ -14,7 +14,7 @@
         <RepositoryType>git</RepositoryType>
         <PackageTags>FIKS</PackageTags>
         <VersionPrefix>1.0.4</VersionPrefix>
-        <TargetFrameworks>netstandard2.1;netcoreapp3.1</TargetFrameworks>
+        <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
         <IncludeSymbols>true</IncludeSymbols>
         <SymbolPackageFormat>snupkg</SymbolPackageFormat>
         

--- a/KS.Fiks.Maskinporten.Client/MaskinportenClientConfiguration.cs
+++ b/KS.Fiks.Maskinporten.Client/MaskinportenClientConfiguration.cs
@@ -10,7 +10,7 @@ namespace Ks.Fiks.Maskinporten.Client
             string issuer,
             int numberOfSecondsLeftBeforeExpire,
             X509Certificate2 certificate,
-            string? consumerOrg = null)
+            string consumerOrg = null)
         {
             Audience = audience;
             TokenEndpoint = tokenEndpoint;
@@ -26,7 +26,7 @@ namespace Ks.Fiks.Maskinporten.Client
 
         public string Issuer { get; }
         
-        public string? ConsumerOrg { get; }
+        public string ConsumerOrg { get; }
 
         public int NumberOfSecondsLeftBeforeExpire { get; }
 

--- a/KS.Fiks.Maskinporten.Client/TokenRequest.cs
+++ b/KS.Fiks.Maskinporten.Client/TokenRequest.cs
@@ -25,7 +25,7 @@ namespace Ks.Fiks.Maskinporten.Client.Cache
 
         public override int GetHashCode()
         {
-            return HashCode.Combine(Scopes, ConsumerOrg);
+            return (Scopes, ConsumerOrg).GetHashCode();
         }
 
         private bool Equals(TokenRequest other)


### PR DESCRIPTION
We should support netstandard 2.0 as well as the latest dotnet core as this makes it easier for others to use the library as-is