### PR TITLE
Fixed problem with version 1.0.5 on .NET Framework and created unit tests on .NET Framework

### DIFF
--- a/KS.Fiks.Maskinporten.Client.NETFramework.Tests/KS.Fiks.Maskinporten.Client.NETFramework.Tests.csproj
+++ b/KS.Fiks.Maskinporten.Client.NETFramework.Tests/KS.Fiks.Maskinporten.Client.NETFramework.Tests.csproj
@@ -1,0 +1,96 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{258BBA75-CE1B-4FD3-9300-822730ADC59D}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>KS.Fiks.Maskinporten.Client.NETFramework.Tests</RootNamespace>
+    <AssemblyName>KS.Fiks.Maskinporten.Client.NETFramework.Tests</AssemblyName>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <Deterministic>true</Deterministic>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Configuration" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Web" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\KS.Fiks.Maskinporten.Client.Tests\Cache\TokenCacheFixture.cs">
+      <Link>Cache\TokenCacheFixture.cs</Link>
+    </Compile>
+    <Compile Include="..\KS.Fiks.Maskinporten.Client.Tests\Cache\TokenCacheTests.cs">
+      <Link>Cache\TokenCacheTests.cs</Link>
+    </Compile>
+    <Compile Include="..\KS.Fiks.Maskinporten.Client.Tests\MaskinportenClientFixture.cs">
+      <Link>MaskinportenClientFixture.cs</Link>
+    </Compile>
+    <Compile Include="..\KS.Fiks.Maskinporten.Client.Tests\MaskinportenClientTests.cs">
+      <Link>MaskinportenClientTests.cs</Link>
+    </Compile>
+    <Compile Include="..\KS.Fiks.Maskinporten.Client.Tests\TestHelper.cs">
+      <Link>TestHelper.cs</Link>
+    </Compile>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="..\KS.Fiks.Maskinporten.Client.Tests\alice-virksomhetssertifikat.p12">
+      <Link>alice-virksomhetssertifikat.p12</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="..\KS.Fiks.Maskinporten.Client.Tests\bob-virksomhetssertifikat.p12">
+      <Link>bob-virksomhetssertifikat.p12</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\KS.Fiks.Maskinporten.Client\KS.Fiks.Maskinporten.Client.csproj">
+      <Project>{f94e2a6a-2ab3-4a25-8f44-9666abe47126}</Project>
+      <Name>KS.Fiks.Maskinporten.Client</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions">
+      <Version>5.10.3</Version>
+    </PackageReference>
+    <PackageReference Include="JWT">
+      <Version>7.3.0</Version>
+    </PackageReference>
+    <PackageReference Include="Moq">
+      <Version>4.14.7</Version>
+    </PackageReference>
+    <PackageReference Include="xunit">
+      <Version>2.4.1</Version>
+    </PackageReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/KS.Fiks.Maskinporten.Client.NETFramework.Tests/Properties/AssemblyInfo.cs
+++ b/KS.Fiks.Maskinporten.Client.NETFramework.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("KS.Fiks.Maskinporten.Client.NETFramework.Tests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("KS.Fiks.Maskinporten.Client.NETFramework.Tests")]
+[assembly: AssemblyCopyright("Copyright ©  2020")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("258bba75-ce1b-4fd3-9300-822730adc59d")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/KS.Fiks.Maskinporten.Client.Tests/TestHelper.cs
+++ b/KS.Fiks.Maskinporten.Client.Tests/TestHelper.cs
@@ -66,15 +66,15 @@ namespace Ks.Fiks.Maskinporten.Client.Tests
 
             var builder = new JwtBuilder()
                 .WithAlgorithmFactory(_factory)
-                .WithAlgorithm(new RS256Algorithm(Certificate))
+                .WithAlgorithm(new RS256Algorithm(Certificate.GetRSAPublicKey(), Certificate.GetRSAPrivateKey()))
                 .WithSerializer(_serializer)
                 .WithValidator(_validator)
                 .WithSecret("passord")
                 .AddHeader(HeaderName.KeyId, keyId);
 
-            foreach (var (key, value) in claims)
+            foreach (var kvp in claims)
             {
-                builder.AddClaim(key, value);
+                builder.AddClaim(kvp.Key, kvp.Value);
             }
 
             return builder.Encode();

--- a/KS.Fiks.Maskinporten.Client/Jwt/JwtRequestTokenGenerator.cs
+++ b/KS.Fiks.Maskinporten.Client/Jwt/JwtRequestTokenGenerator.cs
@@ -34,7 +34,7 @@ namespace Ks.Fiks.Maskinporten.Client.Jwt
         {
             _certificate = certificate;
             _encoder = new JwtEncoder(
-                new RS256Algorithm(_certificate),
+                new RS256Algorithm(_certificate.GetRSAPublicKey(), _certificate.GetRSAPrivateKey()),
                 new JsonNetSerializer(),
                 new JwtBase64UrlEncoder());
         }

--- a/MaskinportenClient.sln
+++ b/MaskinportenClient.sln
@@ -1,10 +1,15 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "KS.Fiks.Maskinporten.Client", "KS.Fiks.Maskinporten.Client\KS.Fiks.Maskinporten.Client.csproj", "{F94E2A6A-2AB3-4A25-8F44-9666ABE47126}"
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30621.155
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "KS.Fiks.Maskinporten.Client", "KS.Fiks.Maskinporten.Client\KS.Fiks.Maskinporten.Client.csproj", "{F94E2A6A-2AB3-4A25-8F44-9666ABE47126}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "KS.Fiks.Maskinporten.Client.Tests", "KS.Fiks.Maskinporten.Client.Tests\KS.Fiks.Maskinporten.Client.Tests.csproj", "{539576C9-1243-4DDC-A81F-D9CC0C36715B}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "KS.Fiks.Maskinporten.Client.Tests", "KS.Fiks.Maskinporten.Client.Tests\KS.Fiks.Maskinporten.Client.Tests.csproj", "{539576C9-1243-4DDC-A81F-D9CC0C36715B}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ExampleApplication", "ExampleApplication\ExampleApplication.csproj", "{F3086324-A728-465A-81FE-9E2783461528}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ExampleApplication", "ExampleApplication\ExampleApplication.csproj", "{F3086324-A728-465A-81FE-9E2783461528}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "KS.Fiks.Maskinporten.Client.NETFramework.Tests", "KS.Fiks.Maskinporten.Client.NETFramework.Tests\KS.Fiks.Maskinporten.Client.NETFramework.Tests.csproj", "{258BBA75-CE1B-4FD3-9300-822730ADC59D}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -24,5 +29,15 @@ Global
 		{F3086324-A728-465A-81FE-9E2783461528}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F3086324-A728-465A-81FE-9E2783461528}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F3086324-A728-465A-81FE-9E2783461528}.Release|Any CPU.Build.0 = Release|Any CPU
+		{258BBA75-CE1B-4FD3-9300-822730ADC59D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{258BBA75-CE1B-4FD3-9300-822730ADC59D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{258BBA75-CE1B-4FD3-9300-822730ADC59D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{258BBA75-CE1B-4FD3-9300-822730ADC59D}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {8BC2E75F-E6C7-45F1-921F-9DA93558AFD4}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
- Created unit tests for .NET Framework (using code links to the existing tests). 
- Fixed problem with version 1.0.5 on .NET Framework. 
- I also had to modify the tests a bit, since the current setup throws ObjectDisposedException when accessing the request in the verify part on .NET Framework (since HttpClient seems to call dispose on the HttpContent on .NET Framework). I also had to increase a 1 second limit to 2 seconds, since .NET Framework is slower than .NET Core.
- All tests are now green and the same amount of code should be tested.
- The build fails on Jenkins, but this might be because Jenkins does not support .NET Framework? Difficult to say without access to the logs. Anyway, the code builds and works on a windows PC with Visual Studio.