### PR TITLE
Rename to follow dotnet standard

### DIFF
--- a/KS.Fiks.Maskinporten.Client.Tests/MaskinportenClientConfigurationFactoryTests.cs
+++ b/KS.Fiks.Maskinporten.Client.Tests/MaskinportenClientConfigurationFactoryTests.cs
@@ -10,7 +10,7 @@ namespace Ks.Fiks.Maskinporten.Client.Tests
         {
             const string issuer = "issuer";
             var certificate = TestHelper.Certificate;
-            var maskinportenClientConfiguration = MaskinportenClientConfigurationFactory.createVer2Configuration(issuer, certificate);
+            var maskinportenClientConfiguration = MaskinportenClientConfigurationFactory.CreateVer2Configuration(issuer, certificate);
             maskinportenClientConfiguration.TokenEndpoint.Should()
                 .Be(MaskinportenClientConfigurationFactory.VER2_TOKEN_ENDPOINT);
             maskinportenClientConfiguration.Audience.Should().Be(MaskinportenClientConfigurationFactory.VER2_AUDIENCE);
@@ -23,7 +23,7 @@ namespace Ks.Fiks.Maskinporten.Client.Tests
         {
             const string issuer = "issuer";
             var certificate = TestHelper.Certificate;
-            var maskinportenClientConfiguration = MaskinportenClientConfigurationFactory.createProdConfiguration(issuer, certificate);
+            var maskinportenClientConfiguration = MaskinportenClientConfigurationFactory.CreateProdConfiguration(issuer, certificate);
             maskinportenClientConfiguration.TokenEndpoint.Should()
                 .Be(MaskinportenClientConfigurationFactory.PROD_TOKEN_ENDPOINT);
             maskinportenClientConfiguration.Audience.Should().Be(MaskinportenClientConfigurationFactory.PROD_AUDIENCE);

--- a/KS.Fiks.Maskinporten.Client/KS.Fiks.Maskinporten.Client.csproj
+++ b/KS.Fiks.Maskinporten.Client/KS.Fiks.Maskinporten.Client.csproj
@@ -22,7 +22,6 @@
     <PropertyGroup Condition="'$(Configuration)'=='Release'">
         <SignAssembly>true</SignAssembly>
         <AssemblyOriginatorKeyFile>maskinporten.snk</AssemblyOriginatorKeyFile>
-        <PackageReadmeFile>README.md</PackageReadmeFile>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="JWT" Version="8.7.0" />
@@ -38,10 +37,6 @@
         <None Include="../LICENSE">
             <Pack>true</Pack>
             <PackagePath>/</PackagePath>
-        </None>
-        <None Include="../README.md">
-            <Pack>true</Pack>
-            <PackagePath>.</PackagePath>
         </None>
     </ItemGroup>
 

--- a/KS.Fiks.Maskinporten.Client/KS.Fiks.Maskinporten.Client.csproj
+++ b/KS.Fiks.Maskinporten.Client/KS.Fiks.Maskinporten.Client.csproj
@@ -39,11 +39,10 @@
             <Pack>true</Pack>
             <PackagePath>/</PackagePath>
         </None>
-    </ItemGroup>
-    <ItemGroup Condition="'$(Configuration)'=='Release'">
         <None Include="../README.md">
             <Pack>true</Pack>
-            <PackagePath>/</PackagePath>
-        </None>       
+            <PackagePath>.</PackagePath>
+        </None>
     </ItemGroup>
+
 </Project>

--- a/KS.Fiks.Maskinporten.Client/MaskinportenClientConfigurationFactory.cs
+++ b/KS.Fiks.Maskinporten.Client/MaskinportenClientConfigurationFactory.cs
@@ -10,7 +10,7 @@ namespace Ks.Fiks.Maskinporten.Client
         public const string PROD_TOKEN_ENDPOINT = "https://maskinporten.no/token";
         private const int DEFAULT_NUMBER_SECONDS_LEFT = 10;
 
-        public static MaskinportenClientConfiguration createVer2Configuration(
+        public static MaskinportenClientConfiguration CreateVer2Configuration(
             string issuer,
             X509Certificate2 certificate,
             int numberOfSecondsLeftBeforeExpire = DEFAULT_NUMBER_SECONDS_LEFT,
@@ -21,7 +21,7 @@ namespace Ks.Fiks.Maskinporten.Client
                 consumerOrg);
         }
 
-        public static MaskinportenClientConfiguration createProdConfiguration(
+        public static MaskinportenClientConfiguration CreateProdConfiguration(
             string issuer,
             X509Certificate2 certificate,
             int numberOfSecondsLeftBeforeExpire = DEFAULT_NUMBER_SECONDS_LEFT,

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ Install [KS.Fiks.Maskinporten.Client](https://www.nuget.org/packages/KS.Fiks.Mas
 #### Using factory for VER2 and PROD environments
 ```c#
 // For VER2 (test)
-var maskinportenConfigVer2 = MaskinportenClientConfigurationFactory.createVer2Configuration("ver2_issuer", testCertificate);
+var maskinportenConfigVer2 = MaskinportenClientConfigurationFactory.CreateVer2Configuration("ver2_issuer", testCertificate);
 // For PROD
-var maskinportenConfigProd = MaskinportenClientConfigurationFactory.createProdConfiguration("prod_issuer", certificate);
+var maskinportenConfigProd = MaskinportenClientConfigurationFactory.CreateProdConfiguration("prod_issuer", certificate);
 ```
 #### Complete configuration
 ```c#


### PR DESCRIPTION
The name of the new factory methods introduced in the previous release should follow dotnet standard naming conventions