### PR TITLE
Added support for JsonWebKey with samples

### DIFF
--- a/ExampleApplication/ExampleApplication.csproj
+++ b/ExampleApplication/ExampleApplication.csproj
@@ -6,6 +6,14 @@
     </PropertyGroup>
 
     <ItemGroup>
+      <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
+      <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="6.0.0" />
+      <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="6.0.1" />
+      <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
+      <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="6.0.1" />
+    </ItemGroup>
+
+    <ItemGroup>
       <ProjectReference Include="..\KS.Fiks.Maskinporten.Client\KS.Fiks.Maskinporten.Client.csproj" />
     </ItemGroup>
 

--- a/KS.Fiks.Maskinporten.Client/JsonWebKeyExtentions.cs
+++ b/KS.Fiks.Maskinporten.Client/JsonWebKeyExtentions.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.IdentityModel.Tokens;
+
+namespace Ks.Fiks.Maskinporten.Client
+{
+    public static class JsonWebKeyExtentions
+    {
+        public static RSA GetRSAPublicKey(this JsonWebKey jwk)
+        {
+            var rsaPublicParameters = new RSAParameters
+            {
+                Exponent = Base64UrlEncoder.DecodeBytes(jwk.E),
+                Modulus = Base64UrlEncoder.DecodeBytes(jwk.N)
+            };
+
+            var rsaPublic = RSA.Create();
+            rsaPublic.ImportParameters(rsaPublicParameters);
+
+            return rsaPublic;
+        }
+
+        public static RSA GetRSAPrivateKey(this JsonWebKey jwk)
+        {
+            var rsaPrivateParameters = new RSAParameters
+            {
+                Exponent = Base64UrlEncoder.DecodeBytes(jwk.E),
+                Modulus = Base64UrlEncoder.DecodeBytes(jwk.N),
+                D = Base64UrlEncoder.DecodeBytes(jwk.D),
+                DP = Base64UrlEncoder.DecodeBytes(jwk.DP),
+                DQ = Base64UrlEncoder.DecodeBytes(jwk.DQ),
+                P = Base64UrlEncoder.DecodeBytes(jwk.P),
+                Q = Base64UrlEncoder.DecodeBytes(jwk.Q),
+                InverseQ = Base64UrlEncoder.DecodeBytes(jwk.QI)
+            };
+
+            var rsaPrivate = RSA.Create();
+            rsaPrivate.ImportParameters(rsaPrivateParameters);
+
+            return rsaPrivate;
+        }
+    }
+}

--- a/KS.Fiks.Maskinporten.Client/Jwt/JwtRequestTokenGeneratorFactory.cs
+++ b/KS.Fiks.Maskinporten.Client/Jwt/JwtRequestTokenGeneratorFactory.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using JWT;
+using JWT.Builder;
+
+namespace Ks.Fiks.Maskinporten.Client.Jwt
+{
+    public static class JwtRequestTokenGeneratorFactory
+    {
+        private const int JwtExpireTimeInMinutes = 2;
+
+        public static IJwtRequestTokenGenerator GetJwtRequestTokenGenerator(MaskinportenClientConfiguration configuration)
+        {
+            IJwtRequestTokenGenerator generator = null;
+
+            if (configuration.RequestType == JwtRequestTokenType.JsonWebKey)
+            {
+                generator = new JwtRequestTokenGeneratorJwk(configuration.Jwk);
+            }
+
+            if (configuration.RequestType == JwtRequestTokenType.X509Certificate)
+            {
+                generator = new JwtRequestTokenGenerator(configuration.Certificate);
+            }
+
+            return generator;
+        }
+
+        public static IDictionary<string, object> CreateJwtPayload(string scope, MaskinportenClientConfiguration configuration)
+        {
+            var jwtData = new JwtData();
+
+            jwtData.Payload.Add("iss", configuration.Issuer);
+            jwtData.Payload.Add("aud", configuration.Audience);
+            jwtData.Payload.Add("iat", UnixEpoch.GetSecondsSince(DateTime.UtcNow));
+            jwtData.Payload.Add("exp", UnixEpoch.GetSecondsSince(DateTime.UtcNow.AddMinutes(JwtExpireTimeInMinutes)));
+            jwtData.Payload.Add("scope", scope);
+            jwtData.Payload.Add("jti", Guid.NewGuid());
+
+            return jwtData.Payload;
+        }
+    }
+}

--- a/KS.Fiks.Maskinporten.Client/Jwt/JwtRequestTokenType.cs
+++ b/KS.Fiks.Maskinporten.Client/Jwt/JwtRequestTokenType.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Ks.Fiks.Maskinporten.Client.Jwt
+{
+    public enum JwtRequestTokenType
+    {
+        X509Certificate,
+        JsonWebKey
+    }
+}

--- a/KS.Fiks.Maskinporten.Client/KS.Fiks.Maskinporten.Client.csproj
+++ b/KS.Fiks.Maskinporten.Client/KS.Fiks.Maskinporten.Client.csproj
@@ -26,6 +26,7 @@
     <ItemGroup>
         <PackageReference Include="JWT" Version="9.0.3" />
         <PackageReference Include="KS.Fiks.QA" Version="1.0.0" PrivateAssets="All" />
+        <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="6.20.0" />
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
         <PackageReference Include="Newtonsoft.Json" Version="[11.0.1, 13.0.1]" />
     </ItemGroup>

--- a/KS.Fiks.Maskinporten.Client/MaskinportenClient.cs
+++ b/KS.Fiks.Maskinporten.Client/MaskinportenClient.cs
@@ -29,7 +29,7 @@ namespace Ks.Fiks.Maskinporten.Client
             _configuration = configuration;
             _httpClient = httpClient ?? new HttpClient();
             _tokenCache = new TokenCache();
-            _tokenGenerator = new JwtRequestTokenGenerator(_configuration.Certificate);
+            _tokenGenerator = JwtRequestTokenGeneratorFactory.GetJwtRequestTokenGenerator(configuration);
         }
 
         public async Task<MaskinportenToken> GetAccessToken(IEnumerable<string> scopes)

--- a/KS.Fiks.Maskinporten.Client/MaskinportenClientConfiguration.cs
+++ b/KS.Fiks.Maskinporten.Client/MaskinportenClientConfiguration.cs
@@ -1,4 +1,6 @@
 using System.Security.Cryptography.X509Certificates;
+using Ks.Fiks.Maskinporten.Client.Jwt;
+using Microsoft.IdentityModel.Tokens;
 
 namespace Ks.Fiks.Maskinporten.Client
 {
@@ -9,8 +11,10 @@ namespace Ks.Fiks.Maskinporten.Client
             string tokenEndpoint,
             string issuer,
             int numberOfSecondsLeftBeforeExpire,
-            X509Certificate2 certificate,
-            string consumerOrg = null)
+            X509Certificate2 certificate = null,
+            string consumerOrg = null,
+            JwtRequestTokenType requestType = JwtRequestTokenType.X509Certificate,
+            JsonWebKey jwk = null)
         {
             Audience = audience;
             TokenEndpoint = tokenEndpoint;
@@ -18,6 +22,8 @@ namespace Ks.Fiks.Maskinporten.Client
             NumberOfSecondsLeftBeforeExpire = numberOfSecondsLeftBeforeExpire;
             Certificate = certificate;
             ConsumerOrg = consumerOrg;
+            RequestType = requestType;
+            Jwk = jwk;
         }
 
         public string Audience { get; }
@@ -31,5 +37,9 @@ namespace Ks.Fiks.Maskinporten.Client
         public int NumberOfSecondsLeftBeforeExpire { get; }
 
         public X509Certificate2 Certificate { get; }
+
+        public JwtRequestTokenType RequestType { get; }
+
+        public JsonWebKey Jwk{ get; }
     }
 }

--- a/KS.Fiks.Maskinporten.Client/MaskinportenClientConfigurationFactory.cs
+++ b/KS.Fiks.Maskinporten.Client/MaskinportenClientConfigurationFactory.cs
@@ -1,3 +1,5 @@
+using Ks.Fiks.Maskinporten.Client.Jwt;
+using Microsoft.IdentityModel.Tokens;
 using System.Security.Cryptography.X509Certificates;
 
 namespace Ks.Fiks.Maskinporten.Client
@@ -30,6 +32,41 @@ namespace Ks.Fiks.Maskinporten.Client
             return new MaskinportenClientConfiguration(PROD_AUDIENCE,
                 PROD_TOKEN_ENDPOINT, issuer, numberOfSecondsLeftBeforeExpire, certificate,
                 consumerOrg);
+        }
+
+        //JWK
+        public static MaskinportenClientConfiguration CreateVer2Configuration(
+            string issuer,
+            JsonWebKey jwk,
+            int numberOfSecondsLeftBeforeExpire = DEFAULT_NUMBER_SECONDS_LEFT,
+            string consumerOrg = null)
+        {
+            return new MaskinportenClientConfiguration(
+                VER2_AUDIENCE,
+                VER2_TOKEN_ENDPOINT,
+                issuer,
+                numberOfSecondsLeftBeforeExpire,
+                null,
+                consumerOrg,
+                JwtRequestTokenType.JsonWebKey,
+                jwk);
+        }
+
+        public static MaskinportenClientConfiguration CreateProdConfiguration(
+            string issuer,
+            JsonWebKey jwk,
+            int numberOfSecondsLeftBeforeExpire = DEFAULT_NUMBER_SECONDS_LEFT,
+            string consumerOrg = null)
+        {
+            return new MaskinportenClientConfiguration(
+                PROD_AUDIENCE,
+                PROD_TOKEN_ENDPOINT,
+                issuer,
+                numberOfSecondsLeftBeforeExpire,
+                null,
+                consumerOrg,
+                JwtRequestTokenType.JsonWebKey,
+                jwk);
         }
     }
 }


### PR DESCRIPTION
Might be too many changes in one go, but I'll give it a try. We can discuss them and then adjust the payload.

I have introduced ConfigurationBuilder into the sample project to support appsettings, secrets and arguments in addition to environment variables. Ive also included samples for reading certificate from windows certificate store and using jwk's.  All this can be removed and is "extra"

Ive added a new TokenGenerator since I found an interface for it, so guessed this was the desired approach

### Added support for JsonWebKey
Added Dependancies for JsonWebKey support using Microsoft.IdentityModel.Tokens

Summary of changes
Added configuration fields for jwk and setting token generator type (X509 default or Jwk)
Added TokenGenerator using jwk
Added TokenGeneratorFactory selecting correct token generator based on config
Added ClientConfigurationFactory methods to simplify using JsonWebKeys

Example usage
```
var jwkJson = System.IO.File.ReadAllText(_configuration["PATH_TO_JWKFILE"]);
var jwk = new JsonWebKey(jwkJson);

string issuer = _configuration["MASKINPORTEN_ISSUER"];

var configuration = MaskinportenClientConfigurationFactory.CreateVer2Configuration(issuer, jwk);

var maskinportenClient = new MaskinportenClient(configuration);
```

###Other question
Identitymodel.Tokens might replace JWT external library?
Needs test?
Not tested with Delegated