### PR TITLE
La til støtte for Onbehalfof forespørsler, som KRR benytter.

### DIFF
--- a/KS.Fiks.Maskinporten.Client/IMaskinportenClient.cs
+++ b/KS.Fiks.Maskinporten.Client/IMaskinportenClient.cs
@@ -12,5 +12,9 @@ namespace Ks.Fiks.Maskinporten.Client
         Task<MaskinportenToken> GetDelegatedAccessToken(string consumerOrg, IEnumerable<string> scopes);
 
         Task<MaskinportenToken> GetDelegatedAccessToken(string consumerOrg, string scopes);
+
+        Task<MaskinportenToken> GetOnBehalfOfAccessToken(string consumerOrg, IEnumerable<string> scopes);
+
+        Task<MaskinportenToken> GetOnBehalfOfAccessToken(string consumerOrg, string scopes);
     }
 }

--- a/KS.Fiks.Maskinporten.Client/Jwt/JwtRequestTokenGenerator.cs
+++ b/KS.Fiks.Maskinporten.Client/Jwt/JwtRequestTokenGenerator.cs
@@ -22,6 +22,12 @@ namespace Ks.Fiks.Maskinporten.Client.Jwt
             var jwtData = new JwtData();
 
             jwtData.Payload.Add("iss", configuration.Issuer);
+
+            if (!string.IsNullOrEmpty(tokenRequest.OnBehalfOf))
+            {
+                jwtData.Payload.Add("iss_onbehalfof", tokenRequest.OnBehalfOf);
+            }
+
             jwtData.Payload.Add("aud", configuration.Audience);
             jwtData.Payload.Add("iat", UnixEpoch.GetSecondsSince(DateTime.UtcNow));
             jwtData.Payload.Add("exp", UnixEpoch.GetSecondsSince(DateTime.UtcNow.AddMinutes(JwtExpireTimeInMinutes)));

--- a/KS.Fiks.Maskinporten.Client/MaskinportenClient.cs
+++ b/KS.Fiks.Maskinporten.Client/MaskinportenClient.cs
@@ -61,6 +61,20 @@ namespace Ks.Fiks.Maskinporten.Client
             }).ConfigureAwait(false);
         }
 
+        public async Task<MaskinportenToken> GetOnBehalfOfAccessToken(string consumerOrg, IEnumerable<string> scopes)
+        {
+            return await GetOnBehalfOfAccessToken(consumerOrg, ScopesAsString(scopes)).ConfigureAwait(false);
+        }
+
+        public async Task<MaskinportenToken> GetOnBehalfOfAccessToken(string consumerOrg, string scopes)
+        {
+            return await GetAccessTokenForRequest(new TokenRequest
+            {
+                Scopes = scopes,
+                OnBehalfOf = consumerOrg
+            }).ConfigureAwait(false);
+        }
+
         private async Task<MaskinportenToken> GetAccessTokenForRequest(TokenRequest tokenRequest)
         {
             return await this._tokenCache.GetToken(

--- a/KS.Fiks.Maskinporten.Client/TokenRequest.cs
+++ b/KS.Fiks.Maskinporten.Client/TokenRequest.cs
@@ -8,6 +8,8 @@ namespace Ks.Fiks.Maskinporten.Client.Cache
 
         public string ConsumerOrg { get; set; }
 
+        public string OnBehalfOf { get; set; }
+
         public override bool Equals(object obj)
         {
             if (ReferenceEquals(null, obj))
@@ -25,12 +27,12 @@ namespace Ks.Fiks.Maskinporten.Client.Cache
 
         public override int GetHashCode()
         {
-            return (Scopes, ConsumerOrg).GetHashCode();
+            return (Scopes, ConsumerOrg, OnBehalfOf).GetHashCode();
         }
 
         private bool Equals(TokenRequest other)
         {
-            return Scopes == other.Scopes && ConsumerOrg == other.ConsumerOrg;
+            return Scopes == other.Scopes && ConsumerOrg == other.ConsumerOrg && OnBehalfOf == other.OnBehalfOf;
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -47,6 +47,14 @@ var accessToken = await maskinportenClient.GetDelegatedAccessToken(consumerOrgNo
 ```
 For more information on this feature, check the [delegation documentation](https://docs.digdir.no/maskinporten_func_delegering.html) at DigDir
 
+### Get on behalf of access token
+```c#
+var scope = "ks:fiks"; // Scope for access token
+var consumerOrgNo = ...; // Official 9 digit organization number for an organization that has delegated access to you in ALTINN
+var accessToken = await maskinportenClient.GetOnBehalfOfAccessToken(consumerOrgNo, scope);
+```
+For more information on this feature, check the [onbehalfof documentation](https://docs.digdir.no/docs/idporten/oidc/oidc_api_admin_leverand%C3%B8r.html#1-onbehalfof-i-id-porten) at DigDir
+
 ### Send request using access token
 ```c#
 var httpClient = new HttpClient();


### PR DESCRIPTION
Kontakt- og reservasjonsregisteret bruker Onbehalfof (https://docs.digdir.no/docs/idporten/oidc/oidc_api_admin_leverand%C3%B8r.html#1-onbehalfof-i-id-porten) funksjonaliteten, så støtte for det er nå lagt til her.
