### PR TITLE
Added info on integrity

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 
 
 ## About this library
-This library is a .net core library for maskinporten authorization through ID-porten.
-There is is also available a similar version for Java [here](). 
+This is a .NET library for Maskinporten authentication and authorization.
+There is also a similar version available for Java [here](https://github.com/ks-no/fiks-maskinporten)
 
 ### Integrity 
 The nuget package is signed with a KS certificate in our build process, stored securely in a safe build environment.

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ var maskinportenConfigVer2 = MaskinportenClientConfigurationFactory.CreateVer2Co
 
 ```c#
 var maskinportenConfig = new MaskinportenClientConfiguration(
-    audience: @"https://test.maskinporten.no/", // ID-porten audience path
-    tokenEndpoint: @"https://test.maskinporten.no/token", // ID-porten token path
+    audience: @"https://test.maskinporten.no/", // Maskinporten audience path
+    tokenEndpoint: @"https://test.maskinporten.no/token", // Maskinporten token path
     issuer: @"issuer",  // Issuer name, heter nå Integrasjonens identifikator i selvbetjeningsløsningen til DigDir
     numberOfSecondsLeftBeforeExpire: 10, // The token will be refreshed 10 seconds before it expires
     certificate: /* virksomhetssertifikat as a X509Certificate2  */,
@@ -40,8 +40,8 @@ var maskinportenConfig = new MaskinportenClientConfiguration(
 
 ```c#
 var maskinportenConfig = new MaskinportenClientConfiguration(
-    audience: @"https://ver2.maskinporten.no/", // ID-porten audience path
-    tokenEndpoint: @"https://ver2.maskinporten.no/token", // ID-porten token path
+    audience: @"https://ver2.maskinporten.no/", // Maskinporten audience path
+    tokenEndpoint: @"https://ver2.maskinporten.no/token", // Maskinporten token path
     issuer: @"issuer",  // Issuer name, heter nå Integrasjonens identifikator i selvbetjeningsløsningen til DigDir
     numberOfSecondsLeftBeforeExpire: 10, // The token will be refreshed 10 seconds before it expires
     certificate: /* virksomhetssertifikat as a X509Certificate2  */,

--- a/README.md
+++ b/README.md
@@ -3,8 +3,13 @@
 [![Nuget](https://img.shields.io/nuget/v/KS.fiks.maskinporten.client.svg)](https://www.nuget.org/packages/KS.Fiks.Maskinporten.Client)
 [![GitHub issues](https://img.shields.io/github/issues-raw/ks-no/kryptering-dotnet.svg)](//github.com/ks-no/fiks-maskinporten-client-dotnet/issues)
 
-.net core library for maskinporten authorization through ID-porten
 
+## About this library
+This library is a .net core library for maskinporten authorization through ID-porten.
+There is is also available a similar version for Java [here](). 
+
+### Integrity 
+The nuget package is signed with a KS certificate in our build process, stored securely in a safe build environment.
 
 ## Installation
 Install [KS.Fiks.Maskinporten.Client](https://www.nuget.org/packages/KS.Fiks.Maskinporten.Client) nuget package in your .net project.


### PR DESCRIPTION
Lagt til informasjon om integritet og signert pakke.
Det ble etterspurt mer informasjon om sikkerhet og integriteten til våre nuget-pakker. Landet på at det er best å ha det i README til github prosjektet siden det er der man gjerne går fra en .nuget pakke.
Kom gjerne med forslag til mer tekst her @helgeskjellevik og @Kolbein 

Korrigerte også en liten missvisende sak i eksempelkode da det står ID-porten men bør stå maskinporten i kommentaren