### PR TITLE
Implemented method to get delegated accesstoken, with a specified audience.

### DIFF
--- a/KS.Fiks.Maskinporten.Client/IMaskinportenClient.cs
+++ b/KS.Fiks.Maskinporten.Client/IMaskinportenClient.cs
@@ -13,6 +13,10 @@ namespace Ks.Fiks.Maskinporten.Client
 
         Task<MaskinportenToken> GetDelegatedAccessToken(string consumerOrg, string scopes);
 
+        Task<MaskinportenToken> GetDelegatedAccessTokenForAudience(string consumerOrg, string audience, IEnumerable<string> scopes);
+
+        Task<MaskinportenToken> GetDelegatedAccessTokenForAudience(string consumerOrg, string audience, string scopes);
+
         Task<MaskinportenToken> GetOnBehalfOfAccessToken(string consumerOrg, IEnumerable<string> scopes);
 
         Task<MaskinportenToken> GetOnBehalfOfAccessToken(string consumerOrg, string scopes);

--- a/KS.Fiks.Maskinporten.Client/Jwt/JwtRequestTokenGenerator.cs
+++ b/KS.Fiks.Maskinporten.Client/Jwt/JwtRequestTokenGenerator.cs
@@ -32,6 +32,11 @@ namespace Ks.Fiks.Maskinporten.Client.Jwt
                 jwtData.Payload.Add("iss_onbehalfof", tokenRequest.OnBehalfOf);
             }
 
+            if (!string.IsNullOrEmpty(tokenRequest.Audience))
+            {
+                jwtData.Payload.Add("resource", tokenRequest.Audience);
+            }
+
             jwtData.Payload.Add("aud", configuration.Audience);
             jwtData.Payload.Add("iat", UnixEpoch.GetSecondsSince(DateTime.UtcNow));
             jwtData.Payload.Add("exp", UnixEpoch.GetSecondsSince(DateTime.UtcNow.AddMinutes(JwtExpireTimeInMinutes)));

--- a/KS.Fiks.Maskinporten.Client/MaskinportenClient.cs
+++ b/KS.Fiks.Maskinporten.Client/MaskinportenClient.cs
@@ -71,6 +71,21 @@ namespace Ks.Fiks.Maskinporten.Client
             }).ConfigureAwait(false);
         }
 
+        public async Task<MaskinportenToken> GetDelegatedAccessTokenForAudience(string consumerOrg, string audience, IEnumerable<string> scopes)
+        {
+            return await GetDelegatedAccessTokenForAudience(consumerOrg, audience, ScopesAsString(scopes)).ConfigureAwait(false);
+        }
+
+        public async Task<MaskinportenToken> GetDelegatedAccessTokenForAudience(string consumerOrg, string audience, string scopes)
+        {
+            return await GetAccessTokenForRequest(new TokenRequest
+            {
+                Audience = audience,
+                Scopes = scopes,
+                ConsumerOrg = consumerOrg
+            }).ConfigureAwait(false);
+        }
+
         public async Task<MaskinportenToken> GetOnBehalfOfAccessToken(string consumerOrg, IEnumerable<string> scopes)
         {
             return await GetOnBehalfOfAccessToken(consumerOrg, ScopesAsString(scopes)).ConfigureAwait(false);

--- a/KS.Fiks.Maskinporten.Client/TokenRequest.cs
+++ b/KS.Fiks.Maskinporten.Client/TokenRequest.cs
@@ -10,6 +10,8 @@ namespace Ks.Fiks.Maskinporten.Client.Cache
 
         public string OnBehalfOf { get; set; }
 
+        public string Audience { get; set; }
+
         public override bool Equals(object obj)
         {
             if (ReferenceEquals(null, obj))

--- a/README.md
+++ b/README.md
@@ -71,6 +71,15 @@ var accessToken = await maskinportenClient.GetDelegatedAccessToken(consumerOrgNo
 ```
 For more information on this feature, check the [delegation documentation](https://docs.digdir.no/maskinporten_func_delegering.html) at DigDir
 
+### Get delegated access audience-restricted token  
+```c#
+var audience = "https://some/api"; // Audience for access token
+var scope = "ks:fiks"; // Scope for access token
+var consumerOrgNo = ...; // Official 9 digit organization number for an organization that has delegated access to you in ALTINN
+var accessToken = await maskinportenClient.GetDelegatedAccessTokenForAudience(consumerOrgNo, audience, scope);
+```
+For more information on this feature, check the [delegation documentation](https://docs.digdir.no/maskinporten_func_delegering.html) [audience-restricted tokens](https://docs.digdir.no/docs/Maskinporten/maskinporten_func_audience_restricted_tokens) at DigDir
+
 ### Get on behalf of access token
 *This is a feature with limited usecase*
 ```c#


### PR DESCRIPTION
We need this in Aksio to connect to some of the new API's from NAV.

Digdir documentation: https://docs.digdir.no/docs/Maskinporten/maskinporten_func_audience_restricted_tokens
