### PR TITLE
Add EmphemeralKeySet storage flag for test certificates

### DIFF
--- a/KS.Fiks.Maskinporten.Client.Tests/TestHelper.cs
+++ b/KS.Fiks.Maskinporten.Client.Tests/TestHelper.cs
@@ -35,12 +35,14 @@ namespace Ks.Fiks.Maskinporten.Client.Tests
         public static X509Certificate2 Certificate =>
             new X509Certificate2(
                 "alice-virksomhetssertifikat.p12",
-                "PASSWORD");
+                "PASSWORD",
+                X509KeyStorageFlags.EphemeralKeySet);
 
         public static X509Certificate2 CertificateOtherThanUsedForDecode =>
             new X509Certificate2(
                 "bob-virksomhetssertifikat.p12",
-                "PASSWORD");
+                "PASSWORD",
+                X509KeyStorageFlags.EphemeralKeySet);
 
         public static RSA PublicKey => _publicKey;
 


### PR DESCRIPTION
Legger inn EmphemeralKeySet for å kunne hente keyset fra minne og muligens komme rundt problem med "Keyset does not exist".

https://www.pkisolutions.com/handling-x509keystorageflags-in-applications/
