### PR TITLE
Add optional 'kid' to JWT request

### DIFF
--- a/ExampleApplication/ExampleApplication.csproj
+++ b/ExampleApplication/ExampleApplication.csproj
@@ -2,7 +2,8 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
+        <LangVersion>default</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,5 @@
 dotnetLibPipeline {
     componentTestProject = "fiks-maskinporten-client-dotnet-integration-tests" 
     dtProjectId = "324b45f0-add8-4a4f-b2e5-180147e50859"
+    dotnetVersion = "8.0"
 }

--- a/KS.Fiks.Maskinporten.Client.Tests/KS.Fiks.Maskinporten.Client.Tests.csproj
+++ b/KS.Fiks.Maskinporten.Client.Tests/KS.Fiks.Maskinporten.Client.Tests.csproj
@@ -4,7 +4,7 @@
         <IsPackable>false</IsPackable>
         <IsTestProject>true</IsTestProject>
         <RootNamespace>KS.Fiks.Maskinporten.Client.Tests</RootNamespace>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
 
     </PropertyGroup>
 

--- a/KS.Fiks.Maskinporten.Client.Tests/KS.Fiks.Maskinporten.Client.Tests.csproj
+++ b/KS.Fiks.Maskinporten.Client.Tests/KS.Fiks.Maskinporten.Client.Tests.csproj
@@ -13,7 +13,6 @@
         <PackageReference Include="KS.Fiks.QA" Version="1.0.0" PrivateAssets="All" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
         <PackageReference Include="Moq" Version="4.20.72" />
-        <PackageReference Include="NLog" Version="5.3.4" />
         <PackageReference Include="xunit" Version="2.9.2" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
         </PackageReference>

--- a/KS.Fiks.Maskinporten.Client.Tests/MaskinportenClientFixture.cs
+++ b/KS.Fiks.Maskinporten.Client.Tests/MaskinportenClientFixture.cs
@@ -59,10 +59,15 @@ namespace Ks.Fiks.Maskinporten.Client.Tests
             return this;
         }
 
-        public MaskinportenClientFixture WithKeyPair(RSA publicKey, RSA privateKey, string? keyIdentifier = null)
+        public MaskinportenClientFixture WithKeyPair(RSA publicKey, RSA privateKey)
         {
             _publicKey = publicKey;
             _privateKey = privateKey;
+            return this;
+        }
+
+        public MaskinportenClientFixture WithKeyIdentifier(string keyIdentifier)
+        {
             _keyIdentifier = keyIdentifier;
             return this;
         }

--- a/KS.Fiks.Maskinporten.Client.Tests/MaskinportenClientTests.cs
+++ b/KS.Fiks.Maskinporten.Client.Tests/MaskinportenClientTests.cs
@@ -13,486 +13,485 @@ using Moq;
 using Moq.Protected;
 using Xunit;
 
-namespace Ks.Fiks.Maskinporten.Client.Tests
+namespace Ks.Fiks.Maskinporten.Client.Tests;
+
+public class MaskinportenClientTests
 {
-    public class MaskinportenClientTests
+    private MaskinportenClientFixture _fixture;
+
+    public MaskinportenClientTests()
     {
-        private MaskinportenClientFixture _fixture;
+        _fixture = new MaskinportenClientFixture();
+    }
 
-        public MaskinportenClientTests()
+    [Fact]
+    public async Task ReturnsAccessToken()
+    {
+        var sut = _fixture.CreateSut();
+
+        var accessToken = await sut.GetAccessToken(_fixture.DefaultScopes).ConfigureAwait(false);
+        accessToken.Should().BeOfType<MaskinportenToken>();
+    }
+
+    [Fact]
+    public async Task ReturnsAccessTokenUsingKeyPair()
+    {
+        const string ExpectedAudience = "someAudience";
+        var sut = _fixture
+            .WithAudience(ExpectedAudience)
+            .WithKeyPair(TestHelper.PublicKey, TestHelper.PrivateKey)
+            .CreateSut();
+
+        var accessToken = await sut.GetAccessToken(_fixture.DefaultScopes).ConfigureAwait(false);
+        accessToken.Should().BeOfType<MaskinportenToken>();
+
+        // This verifies that the audience field is encrypted by the sut av possible to decrypt using key pair.
+        _fixture.HttpMessageHandleMock.Protected().Verify(
+            "SendAsync",
+            Times.Exactly(1),
+            ItExpr.Is<HttpRequestMessage>(req =>
+                TestHelper.DeserializedFieldInJwt(
+                    req,
+                    "assertion",
+                    "aud",
+                    new RSAlgorithmFactory(TestHelper.PublicKey, TestHelper.PrivateKey)) == ExpectedAudience),
+            ItExpr.IsAny<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task AssertionDeserializedHasCorrectKeyIdentifier()
+    {
+        const string expectedKeyIdentifier = "testKeyIdentifier";
+        var sut = _fixture
+            .WithKeyPair(TestHelper.PublicKey, TestHelper.PrivateKey)
+            .WithKeyIdentifier(expectedKeyIdentifier)
+            .CreateSut();
+
+        await sut.GetAccessToken(_fixture.DefaultScopes).ConfigureAwait(false);
+
+        _fixture.HttpMessageHandleMock.Protected().Verify(
+            "SendAsync",
+            Times.Exactly(1),
+            ItExpr.Is<HttpRequestMessage>(req =>
+                TestHelper.DeserializedHeadersInJwt(req, "assertion", "kid",
+                    new RSAlgorithmFactory(TestHelper.PublicKey, TestHelper.PrivateKey)) == expectedKeyIdentifier),
+            ItExpr.IsAny<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task AssertionDeserializedDoesNotContainKeyIdentifierWhenNotSet()
+    {
+        var sut = _fixture
+            .WithKeyPair(TestHelper.PublicKey, TestHelper.PrivateKey)
+            .CreateSut();
+
+        await sut.GetAccessToken(_fixture.DefaultScopes).ConfigureAwait(false);
+
+        _fixture.HttpMessageHandleMock.Protected().Verify(
+            "SendAsync",
+            Times.Exactly(1),
+            ItExpr.Is<HttpRequestMessage>(req =>
+                TestHelper.JwtHeadersContainsField(req, "assertion", "kid",
+                    new RSAlgorithmFactory(TestHelper.PublicKey, TestHelper.PrivateKey)) == false),
+            ItExpr.IsAny<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ReturnsAccesstokenWithNonemptyFields()
+    {
+        var sut = _fixture.CreateSut();
+
+        var accessToken = await sut.GetAccessToken(_fixture.DefaultScopes).ConfigureAwait(false);
+
+        accessToken.Token.Should().NotBeEmpty();
+    }
+
+    [Fact]
+    public async Task SendsRequestToTokenEndpoint()
+    {
+        var tokenEndpoint = "https://test.ks.no/api/token";
+
+        var sut = _fixture.WithTokenEndpoint(tokenEndpoint).CreateSut();
+
+        await sut.GetAccessToken(_fixture.DefaultScopes).ConfigureAwait(false);
+
+        _fixture.HttpMessageHandleMock.Protected().Verify(
+            "SendAsync",
+            Times.Exactly(1),
+            ItExpr.Is<HttpRequestMessage>(req =>
+                req.RequestUri == new Uri(tokenEndpoint)),
+            ItExpr.IsAny<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task DoesNotSendRequestTwiceIfSecondCallIsWithinTimelimit()
+    {
+        var sut = _fixture.CreateSut();
+
+        var token1 = await sut.GetAccessToken(_fixture.DefaultScopes).ConfigureAwait(false);
+        await Task.Delay(TimeSpan.FromMilliseconds(100)).ConfigureAwait(false);
+        var token2 = await sut.GetAccessToken(_fixture.DefaultScopes).ConfigureAwait(false);
+
+        token1.Should().Be(token2);
+        _fixture.HttpMessageHandleMock.Protected().Verify(
+            "SendAsync",
+            Times.Exactly(1),
+            ItExpr.Is<HttpRequestMessage>(req => true),
+            ItExpr.IsAny<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task DoesNotSendDelegatedAccessTokenRequestTwiceIfSecondCallIsWithinTimelimit()
+    {
+        const string consumerOrg = "999888999";
+        var sut = _fixture.CreateSut();
+
+        var token1 = await sut.GetDelegatedAccessToken(consumerOrg, _fixture.DefaultScopes).ConfigureAwait(false);
+        await Task.Delay(TimeSpan.FromMilliseconds(100)).ConfigureAwait(false);
+        var token2 = await sut.GetDelegatedAccessToken(consumerOrg, _fixture.DefaultScopes).ConfigureAwait(false);
+
+        token1.Should().Be(token2);
+        _fixture.HttpMessageHandleMock.Protected().Verify(
+            "SendAsync",
+            Times.Exactly(1),
+            ItExpr.Is<HttpRequestMessage>(req => true),
+            ItExpr.IsAny<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task SendsAudienceAsAssertionResourceToTokenEndpoint()
+    {
+        const string audience = "https://localhost/api";
+        var sut = _fixture.CreateSut();
+
+        await sut.GetDelegatedAccessTokenForAudience("999888999", audience, _fixture.DefaultScopes)
+            .ConfigureAwait(false);
+
+        var requestMessage =
+            _fixture.HttpMessageHandleMock.Invocations.Single().Arguments.Single(o => o is HttpRequestMessage) as
+                HttpRequestMessage;
+        requestMessage?.Content.Should().NotBeNull();
+
+        var requestContent = await requestMessage!.Content!.ReadAsStringAsync().ConfigureAwait(false);
+        var contentDict = requestContent.Split("&").Select(p => p.Split("=")).ToDictionary(_ => _[0], _ => _[1]);
+
+        var decoder = new JwtDecoder(
+            new JsonNetSerializer(),
+            new JwtBase64UrlEncoder());
+
+        var assertionData = decoder.DecodeToObject(contentDict["assertion"], false);
+        assertionData["resource"].Should().Be(audience);
+    }
+
+    [Fact]
+    public async Task SendsRequestTwiceIfSecondCallIsOutsideTimelimit()
+    {
+        var sut = _fixture.WithIdportenExpirationDuration(1).CreateSut();
+
+        var token1 = await sut.GetAccessToken(_fixture.DefaultScopes).ConfigureAwait(false);
+        await Task.Delay(TimeSpan.FromMilliseconds(1100)).ConfigureAwait(false);
+        var token2 = await sut.GetAccessToken(_fixture.DefaultScopes).ConfigureAwait(false);
+
+        token1.Should().Be(token2);
+        _fixture.HttpMessageHandleMock.Protected().Verify(
+            "SendAsync",
+            Times.Exactly(2),
+            ItExpr.Is<HttpRequestMessage>(req => true),
+            ItExpr.IsAny<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task DoesNotSendRequestTwiceIfSecondCallIsWithinTimelimitGivenNumberOfSecondsLeftBeforeExpire()
+    {
+        var sut = _fixture.WithIdportenExpirationDuration(10).WithNumberOfSecondsLeftBeforeExpire(8).CreateSut();
+
+        var token1 = await sut.GetAccessToken(_fixture.DefaultScopes).ConfigureAwait(false);
+        await Task.Delay(TimeSpan.FromMilliseconds(100)).ConfigureAwait(false);
+        var token2 = await sut.GetAccessToken(_fixture.DefaultScopes).ConfigureAwait(false);
+
+        token1.Should().Be(token2);
+        _fixture.HttpMessageHandleMock.Protected().Verify(
+            "SendAsync",
+            Times.Exactly(1),
+            ItExpr.Is<HttpRequestMessage>(req => true),
+            ItExpr.IsAny<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task SendsRequestTwiceIfSecondCallIsOutsideTimelimitGivenNumberOfSecondsLeftBeforeExpire()
+    {
+        var sut = _fixture.WithIdportenExpirationDuration(2).WithNumberOfSecondsLeftBeforeExpire(1).CreateSut();
+
+        var token1 = await sut.GetAccessToken(_fixture.DefaultScopes).ConfigureAwait(false);
+        await Task.Delay(TimeSpan.FromMilliseconds(1100)).ConfigureAwait(false);
+        var token2 = await sut.GetAccessToken(_fixture.DefaultScopes).ConfigureAwait(false);
+
+        token1.Should().Be(token2);
+        _fixture.HttpMessageHandleMock.Protected().Verify(
+            "SendAsync",
+            Times.Exactly(2),
+            ItExpr.Is<HttpRequestMessage>(req => true),
+            ItExpr.IsAny<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task SendsGrantTypeInPost()
+    {
+        var sut = _fixture.CreateSut();
+
+        await sut.GetAccessToken(_fixture.DefaultScopes).ConfigureAwait(false);
+
+        _fixture.HttpMessageHandleMock.Protected().Verify(
+            "SendAsync",
+            Times.Exactly(1),
+            ItExpr.Is<HttpRequestMessage>(req =>
+                req.Method == HttpMethod.Post &&
+                TestHelper.RequestContentAsDictionary(req).ContainsKey("grant_type")),
+            ItExpr.IsAny<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task SendsAssertionInPost()
+    {
+        var sut = _fixture.CreateSut();
+
+        await sut.GetAccessToken(_fixture.DefaultScopes).ConfigureAwait(false);
+
+        _fixture.HttpMessageHandleMock.Protected().Verify(
+            "SendAsync",
+            Times.Exactly(1),
+            ItExpr.Is<HttpRequestMessage>(req =>
+                req.Method == HttpMethod.Post &&
+                TestHelper.RequestContentAsDictionary(req).ContainsKey("assertion")),
+            ItExpr.IsAny<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task AssertionIsAValidSerializedJwt()
+    {
+        var sut = _fixture.CreateSut();
+
+        await sut.GetAccessToken(_fixture.DefaultScopes).ConfigureAwait(false);
+
+        _fixture.HttpMessageHandleMock.Protected().Verify(
+            "SendAsync",
+            Times.Exactly(1),
+            ItExpr.Is<HttpRequestMessage>(req =>
+                TestHelper.RequestContentIsJwt(req, "assertion")),
+            ItExpr.IsAny<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task AssertionDeserializedHasCorrectAudience()
+    {
+        var expectedAudience = "testAudience";
+        var sut = _fixture.WithAudience(expectedAudience).CreateSut();
+
+        await sut.GetAccessToken(_fixture.DefaultScopes).ConfigureAwait(false);
+
+        _fixture.HttpMessageHandleMock.Protected().Verify(
+            "SendAsync",
+            Times.Exactly(1),
+            ItExpr.Is<HttpRequestMessage>(req =>
+                TestHelper.DeserializedFieldInJwt(req, "assertion", "aud") == expectedAudience),
+            ItExpr.IsAny<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task AssertionDeserializedHasCorrectIssuer()
+    {
+        var expectedIssuer = "testIssuer";
+        var sut = _fixture.WithIssuer(expectedIssuer).CreateSut();
+
+        await sut.GetAccessToken(_fixture.DefaultScopes).ConfigureAwait(false);
+
+        _fixture.HttpMessageHandleMock.Protected().Verify(
+            "SendAsync",
+            Times.Exactly(1),
+            ItExpr.Is<HttpRequestMessage>(req =>
+                TestHelper.DeserializedFieldInJwt(req, "assertion", "iss") == expectedIssuer),
+            ItExpr.IsAny<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task AssertionDeserializedHasCorrectScope()
+    {
+        var expectedScope = new string[]
         {
-            _fixture = new MaskinportenClientFixture();
-        }
+            "Scope1", "Scope2"
+        };
 
-        [Fact]
-        public async Task ReturnsAccessToken()
+        var expectedScopeAsString = string.Join(" ", expectedScope);
+
+        var sut = _fixture.CreateSut();
+
+        await sut.GetAccessToken(expectedScope).ConfigureAwait(false);
+
+        _fixture.HttpMessageHandleMock.Protected().Verify(
+            "SendAsync",
+            Times.Exactly(1),
+            ItExpr.Is<HttpRequestMessage>(req =>
+                TestHelper.DeserializedFieldInJwt(req, "assertion", "scope") == expectedScopeAsString),
+            ItExpr.IsAny<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task AssertionDeserializedHasIssueTimeWithinASecondOfNow()
+    {
+        var sut = _fixture.CreateSut();
+
+        await sut.GetAccessToken(_fixture.DefaultScopes).ConfigureAwait(false);
+        var now = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+
+        _fixture.HttpMessageHandleMock.Protected().Verify(
+            "SendAsync",
+            Times.Exactly(1),
+            ItExpr.Is<HttpRequestMessage>(req =>
+                TestHelper.DeserializedFieldInJwt<double>(req, "assertion", "iat") <= now + 1 &&
+                TestHelper.DeserializedFieldInJwt<double>(req, "assertion", "iat") >= now - 1),
+            ItExpr.IsAny<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task AssertionDeserializedHasExpieryTimeTwoMinutesAfterNow()
+    {
+        var sut = _fixture.CreateSut();
+
+        await sut.GetAccessToken(_fixture.DefaultScopes).ConfigureAwait(false);
+        var expectedExpiredTime = DateTimeOffset.UtcNow.AddMinutes(2).ToUnixTimeSeconds();
+
+        _fixture.HttpMessageHandleMock.Protected().Verify(
+            "SendAsync",
+            Times.Exactly(1),
+            ItExpr.Is<HttpRequestMessage>(req =>
+                TestHelper.DeserializedFieldInJwt<double>(req, "assertion", "exp") <=
+                expectedExpiredTime + 1 &&
+                TestHelper.DeserializedFieldInJwt<double>(req, "assertion", "exp") >=
+                expectedExpiredTime - 1),
+            ItExpr.IsAny<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task TestHelperThrowsExceptionIfIncorrectSignature()
+    {
+        var sut = _fixture.WithIncorrectCertificate().CreateSut();
+
+        await sut.GetAccessToken(_fixture.DefaultScopes).ConfigureAwait(false);
+        Assert.Throws<SignatureVerificationException>(() =>
         {
-            var sut = _fixture.CreateSut();
-
-            var accessToken = await sut.GetAccessToken(_fixture.DefaultScopes).ConfigureAwait(false);
-            accessToken.Should().BeOfType<MaskinportenToken>();
-        }
-
-        [Fact]
-        public async Task ReturnsAccessTokenUsingKeyPair()
-        {
-            const string ExpectedAudience = "someAudience";
-            var sut = _fixture
-                .WithAudience(ExpectedAudience)
-                .WithKeyPair(TestHelper.PublicKey, TestHelper.PrivateKey)
-                .CreateSut();
-
-            var accessToken = await sut.GetAccessToken(_fixture.DefaultScopes).ConfigureAwait(false);
-            accessToken.Should().BeOfType<MaskinportenToken>();
-
-            // This verifies that the audience field is encrypted by the sut av possible to decrypt using key pair.
             _fixture.HttpMessageHandleMock.Protected().Verify(
                 "SendAsync",
                 Times.Exactly(1),
                 ItExpr.Is<HttpRequestMessage>(req =>
-                    TestHelper.DeserializedFieldInJwt(
-                        req,
-                        "assertion",
-                        "aud",
-                        new RSAlgorithmFactory(TestHelper.PublicKey, TestHelper.PrivateKey)) == ExpectedAudience),
+                    TestHelper.DeserializedFieldInJwt(req, "assertion", "aud") != "nothing"),
                 ItExpr.IsAny<CancellationToken>());
-        }
-
-        [Fact]
-        public async Task AssertionDeserializedHasCorrectKeyIdentifier()
-        {
-            const string expectedKeyIdentifier = "testKeyIdentifier";
-            var sut = _fixture
-                .WithKeyPair(TestHelper.PublicKey, TestHelper.PrivateKey)
-                .WithKeyIdentifier(expectedKeyIdentifier)
-                .CreateSut();
-
-            await sut.GetAccessToken(_fixture.DefaultScopes).ConfigureAwait(false);
-
-            _fixture.HttpMessageHandleMock.Protected().Verify(
-                "SendAsync",
-                Times.Exactly(1),
-                ItExpr.Is<HttpRequestMessage>(req =>
-                    TestHelper.DeserializedHeadersInJwt(req, "assertion", "kid",
-                        new RSAlgorithmFactory(TestHelper.PublicKey, TestHelper.PrivateKey)) == expectedKeyIdentifier),
-                ItExpr.IsAny<CancellationToken>());
-        }
-
-        [Fact]
-        public async Task AssertionDeserializedDoesNotContainKeyIdentifierWhenNotSet()
-        {
-            var sut = _fixture
-                .WithKeyPair(TestHelper.PublicKey, TestHelper.PrivateKey)
-                .CreateSut();
-
-            await sut.GetAccessToken(_fixture.DefaultScopes).ConfigureAwait(false);
-
-            _fixture.HttpMessageHandleMock.Protected().Verify(
-                "SendAsync",
-                Times.Exactly(1),
-                ItExpr.Is<HttpRequestMessage>(req =>
-                    TestHelper.JwtHeadersContainsField(req, "assertion", "kid",
-                        new RSAlgorithmFactory(TestHelper.PublicKey, TestHelper.PrivateKey)) == false),
-                ItExpr.IsAny<CancellationToken>());
-        }
-
-        [Fact]
-        public async Task ReturnsAccesstokenWithNonemptyFields()
-        {
-            var sut = _fixture.CreateSut();
-
-            var accessToken = await sut.GetAccessToken(_fixture.DefaultScopes).ConfigureAwait(false);
-
-            accessToken.Token.Should().NotBeEmpty();
-        }
-
-        [Fact]
-        public async Task SendsRequestToTokenEndpoint()
-        {
-            var tokenEndpoint = "https://test.ks.no/api/token";
-
-            var sut = _fixture.WithTokenEndpoint(tokenEndpoint).CreateSut();
-
-            await sut.GetAccessToken(_fixture.DefaultScopes).ConfigureAwait(false);
-
-            _fixture.HttpMessageHandleMock.Protected().Verify(
-                "SendAsync",
-                Times.Exactly(1),
-                ItExpr.Is<HttpRequestMessage>(req =>
-                    req.RequestUri == new Uri(tokenEndpoint)),
-                ItExpr.IsAny<CancellationToken>());
-        }
-
-        [Fact]
-        public async Task DoesNotSendRequestTwiceIfSecondCallIsWithinTimelimit()
-        {
-            var sut = _fixture.CreateSut();
-
-            var token1 = await sut.GetAccessToken(_fixture.DefaultScopes).ConfigureAwait(false);
-            await Task.Delay(TimeSpan.FromMilliseconds(100)).ConfigureAwait(false);
-            var token2 = await sut.GetAccessToken(_fixture.DefaultScopes).ConfigureAwait(false);
-
-            token1.Should().Be(token2);
-            _fixture.HttpMessageHandleMock.Protected().Verify(
-                "SendAsync",
-                Times.Exactly(1),
-                ItExpr.Is<HttpRequestMessage>(req => true),
-                ItExpr.IsAny<CancellationToken>());
-        }
-
-        [Fact]
-        public async Task DoesNotSendDelegatedAccessTokenRequestTwiceIfSecondCallIsWithinTimelimit()
-        {
-            const string consumerOrg = "999888999";
-            var sut = _fixture.CreateSut();
-
-            var token1 = await sut.GetDelegatedAccessToken(consumerOrg, _fixture.DefaultScopes).ConfigureAwait(false);
-            await Task.Delay(TimeSpan.FromMilliseconds(100)).ConfigureAwait(false);
-            var token2 = await sut.GetDelegatedAccessToken(consumerOrg, _fixture.DefaultScopes).ConfigureAwait(false);
-
-            token1.Should().Be(token2);
-            _fixture.HttpMessageHandleMock.Protected().Verify(
-                "SendAsync",
-                Times.Exactly(1),
-                ItExpr.Is<HttpRequestMessage>(req => true),
-                ItExpr.IsAny<CancellationToken>());
-        }
-
-        [Fact]
-        public async Task SendsAudienceAsAssertionResourceToTokenEndpoint()
-        {
-            const string audience = "https://localhost/api";
-            var sut = _fixture.CreateSut();
-
-            await sut.GetDelegatedAccessTokenForAudience("999888999", audience, _fixture.DefaultScopes)
-                .ConfigureAwait(false);
-
-            var requestMessage =
-                _fixture.HttpMessageHandleMock.Invocations.Single().Arguments.Single(o => o is HttpRequestMessage) as
-                    HttpRequestMessage;
-            requestMessage?.Content.Should().NotBeNull();
-
-            var requestContent = await requestMessage!.Content!.ReadAsStringAsync().ConfigureAwait(false);
-            var contentDict = requestContent.Split("&").Select(p => p.Split("=")).ToDictionary(_ => _[0], _ => _[1]);
-
-            var decoder = new JwtDecoder(
-                new JsonNetSerializer(),
-                new JwtBase64UrlEncoder());
-
-            var assertionData = decoder.DecodeToObject(contentDict["assertion"], false);
-            assertionData["resource"].Should().Be(audience);
-        }
-
-        [Fact]
-        public async Task SendsRequestTwiceIfSecondCallIsOutsideTimelimit()
-        {
-            var sut = _fixture.WithIdportenExpirationDuration(1).CreateSut();
-
-            var token1 = await sut.GetAccessToken(_fixture.DefaultScopes).ConfigureAwait(false);
-            await Task.Delay(TimeSpan.FromMilliseconds(1100)).ConfigureAwait(false);
-            var token2 = await sut.GetAccessToken(_fixture.DefaultScopes).ConfigureAwait(false);
-
-            token1.Should().Be(token2);
-            _fixture.HttpMessageHandleMock.Protected().Verify(
-                "SendAsync",
-                Times.Exactly(2),
-                ItExpr.Is<HttpRequestMessage>(req => true),
-                ItExpr.IsAny<CancellationToken>());
-        }
-
-        [Fact]
-        public async Task DoesNotSendRequestTwiceIfSecondCallIsWithinTimelimitGivenNumberOfSecondsLeftBeforeExpire()
-        {
-            var sut = _fixture.WithIdportenExpirationDuration(10).WithNumberOfSecondsLeftBeforeExpire(8).CreateSut();
-
-            var token1 = await sut.GetAccessToken(_fixture.DefaultScopes).ConfigureAwait(false);
-            await Task.Delay(TimeSpan.FromMilliseconds(100)).ConfigureAwait(false);
-            var token2 = await sut.GetAccessToken(_fixture.DefaultScopes).ConfigureAwait(false);
-
-            token1.Should().Be(token2);
-            _fixture.HttpMessageHandleMock.Protected().Verify(
-                "SendAsync",
-                Times.Exactly(1),
-                ItExpr.Is<HttpRequestMessage>(req => true),
-                ItExpr.IsAny<CancellationToken>());
-        }
-
-        [Fact]
-        public async Task SendsRequestTwiceIfSecondCallIsOutsideTimelimitGivenNumberOfSecondsLeftBeforeExpire()
-        {
-            var sut = _fixture.WithIdportenExpirationDuration(2).WithNumberOfSecondsLeftBeforeExpire(1).CreateSut();
-
-            var token1 = await sut.GetAccessToken(_fixture.DefaultScopes).ConfigureAwait(false);
-            await Task.Delay(TimeSpan.FromMilliseconds(1100)).ConfigureAwait(false);
-            var token2 = await sut.GetAccessToken(_fixture.DefaultScopes).ConfigureAwait(false);
-
-            token1.Should().Be(token2);
-            _fixture.HttpMessageHandleMock.Protected().Verify(
-                "SendAsync",
-                Times.Exactly(2),
-                ItExpr.Is<HttpRequestMessage>(req => true),
-                ItExpr.IsAny<CancellationToken>());
-        }
-
-        [Fact]
-        public async Task SendsGrantTypeInPost()
-        {
-            var sut = _fixture.CreateSut();
-
-            await sut.GetAccessToken(_fixture.DefaultScopes).ConfigureAwait(false);
-
-            _fixture.HttpMessageHandleMock.Protected().Verify(
-                "SendAsync",
-                Times.Exactly(1),
-                ItExpr.Is<HttpRequestMessage>(req =>
-                    req.Method == HttpMethod.Post &&
-                    TestHelper.RequestContentAsDictionary(req).ContainsKey("grant_type")),
-                ItExpr.IsAny<CancellationToken>());
-        }
-
-        [Fact]
-        public async Task SendsAssertionInPost()
-        {
-            var sut = _fixture.CreateSut();
-
-            await sut.GetAccessToken(_fixture.DefaultScopes).ConfigureAwait(false);
-
-            _fixture.HttpMessageHandleMock.Protected().Verify(
-                "SendAsync",
-                Times.Exactly(1),
-                ItExpr.Is<HttpRequestMessage>(req =>
-                    req.Method == HttpMethod.Post &&
-                    TestHelper.RequestContentAsDictionary(req).ContainsKey("assertion")),
-                ItExpr.IsAny<CancellationToken>());
-        }
-
-        [Fact]
-        public async Task AssertionIsAValidSerializedJwt()
-        {
-            var sut = _fixture.CreateSut();
-
-            await sut.GetAccessToken(_fixture.DefaultScopes).ConfigureAwait(false);
-
-            _fixture.HttpMessageHandleMock.Protected().Verify(
-                "SendAsync",
-                Times.Exactly(1),
-                ItExpr.Is<HttpRequestMessage>(req =>
-                    TestHelper.RequestContentIsJwt(req, "assertion")),
-                ItExpr.IsAny<CancellationToken>());
-        }
-
-        [Fact]
-        public async Task AssertionDeserializedHasCorrectAudience()
-        {
-            var expectedAudience = "testAudience";
-            var sut = _fixture.WithAudience(expectedAudience).CreateSut();
-
-            await sut.GetAccessToken(_fixture.DefaultScopes).ConfigureAwait(false);
-
-            _fixture.HttpMessageHandleMock.Protected().Verify(
-                "SendAsync",
-                Times.Exactly(1),
-                ItExpr.Is<HttpRequestMessage>(req =>
-                    TestHelper.DeserializedFieldInJwt(req, "assertion", "aud") == expectedAudience),
-                ItExpr.IsAny<CancellationToken>());
-        }
-
-        [Fact]
-        public async Task AssertionDeserializedHasCorrectIssuer()
-        {
-            var expectedIssuer = "testIssuer";
-            var sut = _fixture.WithIssuer(expectedIssuer).CreateSut();
-
-            await sut.GetAccessToken(_fixture.DefaultScopes).ConfigureAwait(false);
-
-            _fixture.HttpMessageHandleMock.Protected().Verify(
-                "SendAsync",
-                Times.Exactly(1),
-                ItExpr.Is<HttpRequestMessage>(req =>
-                    TestHelper.DeserializedFieldInJwt(req, "assertion", "iss") == expectedIssuer),
-                ItExpr.IsAny<CancellationToken>());
-        }
-
-        [Fact]
-        public async Task AssertionDeserializedHasCorrectScope()
-        {
-            var expectedScope = new string[]
-            {
-                "Scope1", "Scope2"
-            };
-
-            var expectedScopeAsString = string.Join(" ", expectedScope);
-
-            var sut = _fixture.CreateSut();
-
-            await sut.GetAccessToken(expectedScope).ConfigureAwait(false);
-
-            _fixture.HttpMessageHandleMock.Protected().Verify(
-                "SendAsync",
-                Times.Exactly(1),
-                ItExpr.Is<HttpRequestMessage>(req =>
-                    TestHelper.DeserializedFieldInJwt(req, "assertion", "scope") == expectedScopeAsString),
-                ItExpr.IsAny<CancellationToken>());
-        }
-
-        [Fact]
-        public async Task AssertionDeserializedHasIssueTimeWithinASecondOfNow()
-        {
-            var sut = _fixture.CreateSut();
-
-            await sut.GetAccessToken(_fixture.DefaultScopes).ConfigureAwait(false);
-            var now = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
-
-            _fixture.HttpMessageHandleMock.Protected().Verify(
-                "SendAsync",
-                Times.Exactly(1),
-                ItExpr.Is<HttpRequestMessage>(req =>
-                    TestHelper.DeserializedFieldInJwt<double>(req, "assertion", "iat") <= now + 1 &&
-                    TestHelper.DeserializedFieldInJwt<double>(req, "assertion", "iat") >= now - 1),
-                ItExpr.IsAny<CancellationToken>());
-        }
-
-        [Fact]
-        public async Task AssertionDeserializedHasExpieryTimeTwoMinutesAfterNow()
-        {
-            var sut = _fixture.CreateSut();
-
-            await sut.GetAccessToken(_fixture.DefaultScopes).ConfigureAwait(false);
-            var expectedExpiredTime = DateTimeOffset.UtcNow.AddMinutes(2).ToUnixTimeSeconds();
-
-            _fixture.HttpMessageHandleMock.Protected().Verify(
-                "SendAsync",
-                Times.Exactly(1),
-                ItExpr.Is<HttpRequestMessage>(req =>
-                    TestHelper.DeserializedFieldInJwt<double>(req, "assertion", "exp") <=
-                    expectedExpiredTime + 1 &&
-                    TestHelper.DeserializedFieldInJwt<double>(req, "assertion", "exp") >=
-                    expectedExpiredTime - 1),
-                ItExpr.IsAny<CancellationToken>());
-        }
-
-        [Fact]
-        public async Task TestHelperThrowsExceptionIfIncorrectSignature()
-        {
-            var sut = _fixture.WithIncorrectCertificate().CreateSut();
-
-            await sut.GetAccessToken(_fixture.DefaultScopes).ConfigureAwait(false);
-            Assert.Throws<SignatureVerificationException>(() =>
-            {
-                _fixture.HttpMessageHandleMock.Protected().Verify(
-                    "SendAsync",
-                    Times.Exactly(1),
-                    ItExpr.Is<HttpRequestMessage>(req =>
-                        TestHelper.DeserializedFieldInJwt(req, "assertion", "aud") != "nothing"),
-                    ItExpr.IsAny<CancellationToken>());
-            });
-        }
-
-        [Fact]
-        public async Task SendsHeaderCharsetUtf8()
-        {
-            var sut = _fixture.CreateSut();
-
-            await sut.GetAccessToken(_fixture.DefaultScopes).ConfigureAwait(false);
-
-            _fixture.HttpMessageHandleMock.Protected().Verify(
-                "SendAsync",
-                Times.Exactly(1),
-                ItExpr.Is<HttpRequestMessage>(req =>
-                    req.Content.Headers.GetValues("Charset").Contains("utf-8")),
-                ItExpr.IsAny<CancellationToken>());
-        }
-
-        [Fact]
-        public async Task SendsHeaderConsumerOrgIfSet()
-        {
-            var consumerOrg = "123456789";
-            var sut = _fixture.WithConsumerOrg(consumerOrg).CreateSut();
-
-            await sut.GetAccessToken(_fixture.DefaultScopes).ConfigureAwait(false);
-
-            _fixture.HttpMessageHandleMock.Protected().Verify(
-                "SendAsync",
-                Times.Exactly(1),
-                ItExpr.Is<HttpRequestMessage>(req =>
-                    req.Content.Headers.GetValues("consumer_org").Contains(consumerOrg)),
-                ItExpr.IsAny<CancellationToken>());
-        }
-
-        [Fact]
-        public async Task DoesNotSendHeaderConsumerOrgIfNotSet()
-        {
-            var sut = _fixture.WithConsumerOrg(null).CreateSut();
-
-            await sut.GetAccessToken(_fixture.DefaultScopes).ConfigureAwait(false);
-
-            _fixture.HttpMessageHandleMock.Protected().Verify(
-                "SendAsync",
-                Times.Exactly(1),
-                ItExpr.Is<HttpRequestMessage>(req =>
-                    !req.Content.Headers.Contains("consumer_org")),
-                ItExpr.IsAny<CancellationToken>());
-        }
-
-        [Fact]
-        public async Task SendsHeaderCorrectContentType()
-        {
-            var sut = _fixture.CreateSut();
-
-            await sut.GetAccessToken(_fixture.DefaultScopes).ConfigureAwait(false);
-
-            _fixture.HttpMessageHandleMock.Protected().Verify(
-                "SendAsync",
-                Times.Exactly(1),
-                ItExpr.Is<HttpRequestMessage>(req =>
-                    req.Content.Headers.ContentType.MediaType == "application/x-www-form-urlencoded"),
-                ItExpr.IsAny<CancellationToken>());
-        }
-
-        [Fact]
-        public async Task SendsHeaderContentLength()
-        {
-            var sut = _fixture.CreateSut();
-
-            await sut.GetAccessToken(_fixture.DefaultScopes).ConfigureAwait(false);
-
-            _fixture.HttpMessageHandleMock.Protected().Verify(
-                "SendAsync",
-                Times.Exactly(1),
-                ItExpr.Is<HttpRequestMessage>(req =>
-                    req.Content.Headers.ContentLength > 0),
-                ItExpr.IsAny<CancellationToken>());
-        }
-
-        [Fact]
-        public async Task SendsHeaderNoCacheTrue()
-        {
-            var sut = _fixture.CreateSut();
-
-            await sut.GetAccessToken(_fixture.DefaultScopes).ConfigureAwait(false);
-
-            _fixture.HttpMessageHandleMock.Protected().Verify(
-                "SendAsync",
-                Times.Exactly(1),
-                ItExpr.Is<HttpRequestMessage>(req =>
-                    req.Headers.CacheControl.NoCache),
-                ItExpr.IsAny<CancellationToken>());
-        }
-
-        [Theory]
-        [InlineData(HttpStatusCode.NotFound)]
-        [InlineData(HttpStatusCode.Unauthorized)]
-        [InlineData(HttpStatusCode.InternalServerError)]
-        [InlineData(HttpStatusCode.NoContent)]
-        [InlineData(HttpStatusCode.Redirect)]
-        [InlineData(HttpStatusCode.Forbidden)]
-        public async Task ThrowsExceptionIfStatusCodeIsNot200(HttpStatusCode statusCode)
-        {
-            var sut = _fixture.WithStatusCode(statusCode).CreateSut();
-
-            await Assert.ThrowsAsync<UnexpectedResponseException>(
-                    async () => await sut.GetAccessToken(_fixture.DefaultScopes).ConfigureAwait(false))
-                .ConfigureAwait(false);
-        }
+        });
+    }
+
+    [Fact]
+    public async Task SendsHeaderCharsetUtf8()
+    {
+        var sut = _fixture.CreateSut();
+
+        await sut.GetAccessToken(_fixture.DefaultScopes).ConfigureAwait(false);
+
+        _fixture.HttpMessageHandleMock.Protected().Verify(
+            "SendAsync",
+            Times.Exactly(1),
+            ItExpr.Is<HttpRequestMessage>(req =>
+                req.Content.Headers.GetValues("Charset").Contains("utf-8")),
+            ItExpr.IsAny<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task SendsHeaderConsumerOrgIfSet()
+    {
+        var consumerOrg = "123456789";
+        var sut = _fixture.WithConsumerOrg(consumerOrg).CreateSut();
+
+        await sut.GetAccessToken(_fixture.DefaultScopes).ConfigureAwait(false);
+
+        _fixture.HttpMessageHandleMock.Protected().Verify(
+            "SendAsync",
+            Times.Exactly(1),
+            ItExpr.Is<HttpRequestMessage>(req =>
+                req.Content.Headers.GetValues("consumer_org").Contains(consumerOrg)),
+            ItExpr.IsAny<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task DoesNotSendHeaderConsumerOrgIfNotSet()
+    {
+        var sut = _fixture.WithConsumerOrg(null).CreateSut();
+
+        await sut.GetAccessToken(_fixture.DefaultScopes).ConfigureAwait(false);
+
+        _fixture.HttpMessageHandleMock.Protected().Verify(
+            "SendAsync",
+            Times.Exactly(1),
+            ItExpr.Is<HttpRequestMessage>(req =>
+                !req.Content.Headers.Contains("consumer_org")),
+            ItExpr.IsAny<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task SendsHeaderCorrectContentType()
+    {
+        var sut = _fixture.CreateSut();
+
+        await sut.GetAccessToken(_fixture.DefaultScopes).ConfigureAwait(false);
+
+        _fixture.HttpMessageHandleMock.Protected().Verify(
+            "SendAsync",
+            Times.Exactly(1),
+            ItExpr.Is<HttpRequestMessage>(req =>
+                req.Content.Headers.ContentType.MediaType == "application/x-www-form-urlencoded"),
+            ItExpr.IsAny<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task SendsHeaderContentLength()
+    {
+        var sut = _fixture.CreateSut();
+
+        await sut.GetAccessToken(_fixture.DefaultScopes).ConfigureAwait(false);
+
+        _fixture.HttpMessageHandleMock.Protected().Verify(
+            "SendAsync",
+            Times.Exactly(1),
+            ItExpr.Is<HttpRequestMessage>(req =>
+                req.Content.Headers.ContentLength > 0),
+            ItExpr.IsAny<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task SendsHeaderNoCacheTrue()
+    {
+        var sut = _fixture.CreateSut();
+
+        await sut.GetAccessToken(_fixture.DefaultScopes).ConfigureAwait(false);
+
+        _fixture.HttpMessageHandleMock.Protected().Verify(
+            "SendAsync",
+            Times.Exactly(1),
+            ItExpr.Is<HttpRequestMessage>(req =>
+                req.Headers.CacheControl.NoCache),
+            ItExpr.IsAny<CancellationToken>());
+    }
+
+    [Theory]
+    [InlineData(HttpStatusCode.NotFound)]
+    [InlineData(HttpStatusCode.Unauthorized)]
+    [InlineData(HttpStatusCode.InternalServerError)]
+    [InlineData(HttpStatusCode.NoContent)]
+    [InlineData(HttpStatusCode.Redirect)]
+    [InlineData(HttpStatusCode.Forbidden)]
+    public async Task ThrowsExceptionIfStatusCodeIsNot200(HttpStatusCode statusCode)
+    {
+        var sut = _fixture.WithStatusCode(statusCode).CreateSut();
+
+        await Assert.ThrowsAsync<UnexpectedResponseException>(
+                async () => await sut.GetAccessToken(_fixture.DefaultScopes).ConfigureAwait(false))
+            .ConfigureAwait(false);
     }
 }

--- a/KS.Fiks.Maskinporten.Client.Tests/TestHelper.cs
+++ b/KS.Fiks.Maskinporten.Client.Tests/TestHelper.cs
@@ -10,115 +10,148 @@ using JWT.Algorithms;
 using JWT.Builder;
 using JWT.Serializers;
 using Newtonsoft.Json;
-using NLog;
-using NLog.Fluent;
+using Xunit.Abstractions;
+using Xunit.Sdk;
 
-namespace Ks.Fiks.Maskinporten.Client.Tests
+namespace Ks.Fiks.Maskinporten.Client.Tests;
+
+public static class TestHelper
 {
-    public static class TestHelper
-    {
-        private static readonly RSAlgorithmFactory _factory = new RSAlgorithmFactory(() => Certificate);
-        private static readonly JsonNetSerializer _serializer = new JsonNetSerializer();
-        private static readonly JwtValidator _validator = new JwtValidator(_serializer, new UtcDateTimeProvider());
-        private static readonly JwtBase64UrlEncoder _urlEncoder = new JwtBase64UrlEncoder();
-        private static readonly Logger log = LogManager.GetCurrentClassLogger();
-        private static readonly RSA _publicKey = RSA.Create();
-        private static readonly RSA _privateKey = RSA.Create();
+    private static readonly ITestOutputHelper _testOutputHelper = new TestOutputHelper();
+    private static readonly RSAlgorithmFactory _factory = new RSAlgorithmFactory(() => Certificate);
+    private static readonly JsonNetSerializer _serializer = new JsonNetSerializer();
+    private static readonly JwtValidator _validator = new JwtValidator(_serializer, new UtcDateTimeProvider());
+    private static readonly JwtBase64UrlEncoder _urlEncoder = new JwtBase64UrlEncoder();
+    private static readonly RSA _publicKey = RSA.Create();
+    private static readonly RSA _privateKey = RSA.Create();
 
-        public static Dictionary<string, string> RequestContentAsDictionary(HttpRequestMessage request)
+    public static RSA PublicKey => _publicKey;
+
+    public static RSA PrivateKey => _privateKey;
+
+    public static X509Certificate2 Certificate =>
+        new X509Certificate2(
+            "alice-virksomhetssertifikat.p12",
+            "PASSWORD",
+            X509KeyStorageFlags.EphemeralKeySet);
+
+    public static X509Certificate2 CertificateOtherThanUsedForDecode =>
+        new X509Certificate2(
+            "bob-virksomhetssertifikat.p12",
+            "PASSWORD",
+            X509KeyStorageFlags.EphemeralKeySet);
+
+    public static Dictionary<string, string> RequestContentAsDictionary(HttpRequestMessage request)
+    {
+        var formData = request.Content.ReadAsStringAsync().Result;
+        var query = HttpUtility.ParseQueryString(formData);
+        return query.AllKeys.ToDictionary(t => t, t => query[t]);
+    }
+
+    public static bool RequestContentIsJwt(HttpRequestMessage request, string jwtFieldName)
+    {
+        var content = RequestContentAsDictionary(request);
+        var serializedJwt = content[jwtFieldName];
+
+        try
         {
-            var formData = request.Content.ReadAsStringAsync().Result;
-            var query = HttpUtility.ParseQueryString(formData);
-            return query.AllKeys.ToDictionary(t => t, t => query[t]);
+            var decodedJwt = GetDeserializedJwt(serializedJwt, _factory);
+            return decodedJwt?.Length > 0;
+        }
+        catch (Exception ex)
+        {
+            _testOutputHelper.WriteLine("Could not decode JWT");
+            return false;
+        }
+    }
+
+    public static string DeserializedFieldInJwt(HttpRequestMessage request, string jwtFieldName, string field)
+    {
+        return DeserializedFieldInJwt(request, jwtFieldName, field, _factory);
+    }
+
+    public static string DeserializedFieldInJwt(HttpRequestMessage request, string jwtFieldName, string field, IAlgorithmFactory factory)
+    {
+        return DeserializedFieldInJwt<string>(request, jwtFieldName, field, factory);
+    }
+
+    public static string EncodeJwt(string keyId, Dictionary<string, object> claims)
+    {
+        return EncodeJwt(keyId, claims, _factory, new RS256Algorithm(Certificate));
+    }
+
+    public static string EncodeJwt(string keyId, Dictionary<string, object> claims, IAlgorithmFactory factory, IJwtAlgorithm algorithm)
+    {
+
+        var builder = new JwtBuilder()
+            .WithAlgorithmFactory(factory)
+            .WithAlgorithm(algorithm)
+            .WithJsonSerializer(_serializer)
+            .WithValidator(_validator)
+            .WithSecret("passord")
+            .AddHeader(HeaderName.KeyId, keyId);
+
+        foreach (var (key, value) in claims)
+        {
+            builder.AddClaim(key, value);
         }
 
-        public static X509Certificate2 Certificate =>
-            new X509Certificate2(
-                "alice-virksomhetssertifikat.p12",
-                "PASSWORD",
-                X509KeyStorageFlags.EphemeralKeySet);
+        return builder.Encode();
+    }
 
-        public static X509Certificate2 CertificateOtherThanUsedForDecode =>
-            new X509Certificate2(
-                "bob-virksomhetssertifikat.p12",
-                "PASSWORD",
-                X509KeyStorageFlags.EphemeralKeySet);
+    public static T DeserializedFieldInJwt<T>(HttpRequestMessage request, string jwtFieldName, string field, IAlgorithmFactory factory)
+    {
+        var content = RequestContentAsDictionary(request);
+        var serializedJwt = content[jwtFieldName];
+        var deserializedJwt = GetDeserializedJwt(serializedJwt, factory);
 
-        public static RSA PublicKey => _publicKey;
+        var jwtAsDictionary = JsonConvert.DeserializeObject<Dictionary<string, object>>(deserializedJwt);
+        return (T)jwtAsDictionary[field];
+    }
 
-        public static RSA PrivateKey => _privateKey;
+    public static T DeserializedFieldInJwt<T>(HttpRequestMessage request, string jwtFieldName, string field)
+    {
+        return DeserializedFieldInJwt<T>(request, jwtFieldName, field, _factory);
+    }
 
-        public static bool RequestContentIsJwt(HttpRequestMessage request, string jwtFieldName)
+    private static string GetDeserializedJwt(string serializedJwt, IAlgorithmFactory factory)
+    {
+        var decoder = new JwtDecoder(_serializer, _validator, _urlEncoder, factory);
+
+        return decoder.Decode(serializedJwt, "MustBeNonNullButValueDoesNotMatterForRS256", true);
+    }
+
+    public static string DeserializedHeadersInJwt(HttpRequestMessage request, string jwtFieldName, string field, IAlgorithmFactory factory)
+    {
+        var content = RequestContentAsDictionary(request);
+        var serializedJwt = content[jwtFieldName];
+        var decoder = new JwtDecoder(_serializer, _validator, _urlEncoder, factory);
+        var decodedHeader = decoder.DecodeHeader(serializedJwt);
+
+        var headersDictionary = JsonConvert.DeserializeObject<Dictionary<string, object>>(decodedHeader);
+        return (string)headersDictionary[field];
+    }
+
+    public static bool JwtHeadersContainsField(HttpRequestMessage request, string jwtFieldName, string field, IAlgorithmFactory factory)
+    {
+        try
         {
             var content = RequestContentAsDictionary(request);
-            var serializedJwt = content[jwtFieldName];
-
-            try
+            if (!content.TryGetValue(jwtFieldName, out var serializedJwt))
             {
-                var decodedJwt = GetDeserializedJwt(serializedJwt, _factory);
-                return decodedJwt?.Length > 0;
-            }
-            catch (Exception ex)
-            {
-                log.Warn().Exception(ex).Message("Could not decode JWT").Write();
                 return false;
             }
-        }
 
-        public static string DeserializedFieldInJwt(HttpRequestMessage request, string jwtFieldName, string field)
-        {
-            return DeserializedFieldInJwt(request, jwtFieldName, field, _factory);
-        }
-
-        public static string DeserializedFieldInJwt(HttpRequestMessage request, string jwtFieldName, string field, IAlgorithmFactory factory)
-        {
-            return DeserializedFieldInJwt<string>(request, jwtFieldName, field, factory);
-        }
-
-        public static string EncodeJwt(string keyId, Dictionary<string, object> claims)
-        {
-            return EncodeJwt(keyId, claims, _factory, new RS256Algorithm(Certificate));
-        }
-
-        public static string EncodeJwt(string keyId, Dictionary<string, object> claims, IAlgorithmFactory factory, IJwtAlgorithm algorithm)
-        {
-
-            var builder = new JwtBuilder()
-                .WithAlgorithmFactory(factory)
-                .WithAlgorithm(algorithm)
-                .WithJsonSerializer(_serializer)
-                .WithValidator(_validator)
-                .WithSecret("passord")
-                .AddHeader(HeaderName.KeyId, keyId);
-
-            foreach (var (key, value) in claims)
-            {
-                builder.AddClaim(key, value);
-            }
-
-            return builder.Encode();
-        }
-
-        public static T DeserializedFieldInJwt<T>(HttpRequestMessage request, string jwtFieldName, string field, IAlgorithmFactory factory)
-        {
-            var content = RequestContentAsDictionary(request);
-            var serializedJwt = content[jwtFieldName];
-            var deserializedJwt = GetDeserializedJwt(serializedJwt, factory);
-
-            var jwtAsDictionary = JsonConvert.DeserializeObject<Dictionary<string, object>>(deserializedJwt);
-            return (T)jwtAsDictionary[field];
-        }
-
-        public static T DeserializedFieldInJwt<T>(HttpRequestMessage request, string jwtFieldName, string field)
-        {
-            return DeserializedFieldInJwt<T>(request, jwtFieldName, field, _factory);
-        }
-
-        private static string GetDeserializedJwt(string serializedJwt, IAlgorithmFactory factory)
-        {
             var decoder = new JwtDecoder(_serializer, _validator, _urlEncoder, factory);
+            var decodedHeader = decoder.DecodeHeader(serializedJwt);
 
-            return decoder.Decode(serializedJwt, "MustBeNonNullButValueDoesNotMatterForRS256", true);
+            var headersDictionary = JsonConvert.DeserializeObject<Dictionary<string, object>>(decodedHeader);
+            return headersDictionary.ContainsKey(field);
+        }
+        catch (Exception)
+        {
+            _testOutputHelper.WriteLine("Error checking JWT headers");
+            return false;
         }
     }
 }

--- a/KS.Fiks.Maskinporten.Client/Jwt/JwtRequestTokenGenerator.cs
+++ b/KS.Fiks.Maskinporten.Client/Jwt/JwtRequestTokenGenerator.cs
@@ -15,13 +15,13 @@ namespace Ks.Fiks.Maskinporten.Client.Jwt
         private const int JwtExpireTimeInMinutes = 2;
         private const string DummyKey = ""; // Required by encoder, but not used with RS256Algorithm
 
-        private readonly JwtEncoder encoder;
-        private readonly X509Certificate2 certificate;
-        private readonly string keyIdentifier;
-        private readonly RSA privateKey;
-        private readonly RSA publicKey;
+        private readonly JwtEncoder _encoder;
+        private readonly X509Certificate2 _certificate;
+        private readonly string _keyIdentifier;
 
-        private static IDictionary<string, object> CreateJwtPayload(TokenRequest tokenRequest, MaskinportenClientConfiguration configuration)
+        private static IDictionary<string, object> CreateJwtPayload(
+            TokenRequest tokenRequest,
+            MaskinportenClientConfiguration configuration)
         {
             var jwtData = new JwtData();
 
@@ -51,12 +51,13 @@ namespace Ks.Fiks.Maskinporten.Client.Jwt
             return jwtData.Payload;
         }
 
-        public JwtRequestTokenGenerator(X509Certificate2 certificate)
+        public JwtRequestTokenGenerator(X509Certificate2 certificate, string keyIdentifier = null)
         {
-            this.certificate = certificate;
-            this.privateKey = certificate.GetRSAPrivateKey();
-            this.publicKey = certificate.GetRSAPublicKey();
-            this.encoder = new JwtEncoder(
+            _certificate = certificate;
+            var privateKey = certificate.GetRSAPrivateKey();
+            var publicKey = certificate.GetRSAPublicKey();
+            _keyIdentifier = keyIdentifier;
+            _encoder = new JwtEncoder(
                 new RS256Algorithm(publicKey, privateKey),
                 new JsonNetSerializer(),
                 new JwtBase64UrlEncoder());
@@ -64,10 +65,8 @@ namespace Ks.Fiks.Maskinporten.Client.Jwt
 
         public JwtRequestTokenGenerator(RSA publicKey, RSA privateKey, string keyIdentifier = null)
         {
-            this.keyIdentifier = keyIdentifier;
-            this.privateKey = privateKey;
-            this.publicKey = publicKey;
-            this.encoder = new JwtEncoder(
+            _keyIdentifier = keyIdentifier;
+            _encoder = new JwtEncoder(
                 new RS256Algorithm(publicKey, privateKey),
                 new JsonNetSerializer(),
                 new JwtBase64UrlEncoder());
@@ -77,7 +76,7 @@ namespace Ks.Fiks.Maskinporten.Client.Jwt
         {
             var payload = CreateJwtPayload(tokenRequest, configuration);
             var header = CreateJwtHeader();
-            var jwt = this.encoder.Encode(header, payload, DummyKey);
+            var jwt = _encoder.Encode(header, payload, DummyKey);
 
             return jwt;
         }
@@ -86,14 +85,15 @@ namespace Ks.Fiks.Maskinporten.Client.Jwt
         {
             Dictionary<string, object> jwtHeaderValues = new Dictionary<string, object>();
 
-            if (certificate != null)
+            if (_certificate != null)
             {
-                jwtHeaderValues.Add("x5c", new List<string>() { Convert.ToBase64String(this.certificate.Export(X509ContentType.Cert)) });
+                jwtHeaderValues.Add("x5c",
+                    new List<string>() { Convert.ToBase64String(_certificate.Export(X509ContentType.Cert)) });
             }
 
-            if (!string.IsNullOrWhiteSpace(keyIdentifier))
+            if (!string.IsNullOrWhiteSpace(_keyIdentifier))
             {
-                jwtHeaderValues.Add("kid", keyIdentifier);
+                jwtHeaderValues.Add("kid", _keyIdentifier);
             }
 
             return jwtHeaderValues;

--- a/KS.Fiks.Maskinporten.Client/KS.Fiks.Maskinporten.Client.csproj
+++ b/KS.Fiks.Maskinporten.Client/KS.Fiks.Maskinporten.Client.csproj
@@ -14,7 +14,7 @@
         <RepositoryType>git</RepositoryType>
         <PackageTags>FIKS</PackageTags>
         <VersionPrefix>1.2.1</VersionPrefix>
-        <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+        <TargetFrameworks>netstandard2.0;netstandard2.1;net8.0</TargetFrameworks>
         <PublishRepositoryUrl>true</PublishRepositoryUrl>
         <IncludeSymbols>true</IncludeSymbols>
         <SymbolPackageFormat>snupkg</SymbolPackageFormat>

--- a/KS.Fiks.Maskinporten.Client/KS.Fiks.Maskinporten.Client.csproj
+++ b/KS.Fiks.Maskinporten.Client/KS.Fiks.Maskinporten.Client.csproj
@@ -13,7 +13,7 @@
         <PackageIcon>KS.png</PackageIcon>
         <RepositoryType>git</RepositoryType>
         <PackageTags>FIKS</PackageTags>
-        <VersionPrefix>1.2.1</VersionPrefix>
+        <VersionPrefix>2.0.0</VersionPrefix>
         <TargetFrameworks>netstandard2.0;netstandard2.1;net8.0</TargetFrameworks>
         <PublishRepositoryUrl>true</PublishRepositoryUrl>
         <IncludeSymbols>true</IncludeSymbols>

--- a/KS.Fiks.Maskinporten.Client/MaskinportenClient.cs
+++ b/KS.Fiks.Maskinporten.Client/MaskinportenClient.cs
@@ -31,7 +31,9 @@ namespace Ks.Fiks.Maskinporten.Client
             _tokenCache = new TokenCache();
             if (_configuration.Certificate != null)
             {
-                _tokenGenerator = new JwtRequestTokenGenerator(_configuration.Certificate);
+                _tokenGenerator = new JwtRequestTokenGenerator(
+                    _configuration.Certificate,
+                    _configuration.KeyIdentifier);
             }
             else
             {
@@ -71,12 +73,15 @@ namespace Ks.Fiks.Maskinporten.Client
             }).ConfigureAwait(false);
         }
 
-        public async Task<MaskinportenToken> GetDelegatedAccessTokenForAudience(string consumerOrg, string audience, IEnumerable<string> scopes)
+        public async Task<MaskinportenToken> GetDelegatedAccessTokenForAudience(string consumerOrg, string audience,
+            IEnumerable<string> scopes)
         {
-            return await GetDelegatedAccessTokenForAudience(consumerOrg, audience, ScopesAsString(scopes)).ConfigureAwait(false);
+            return await GetDelegatedAccessTokenForAudience(consumerOrg, audience, ScopesAsString(scopes))
+                .ConfigureAwait(false);
         }
 
-        public async Task<MaskinportenToken> GetDelegatedAccessTokenForAudience(string consumerOrg, string audience, string scopes)
+        public async Task<MaskinportenToken> GetDelegatedAccessTokenForAudience(string consumerOrg, string audience,
+            string scopes)
         {
             return await GetAccessTokenForRequest(new TokenRequest
             {
@@ -144,7 +149,8 @@ namespace Ks.Fiks.Maskinporten.Client
             var content = new FormUrlEncodedContent(new List<KeyValuePair<string, string>>()
             {
                 new KeyValuePair<string, string>("grant_type", GrantType),
-                new KeyValuePair<string, string>("assertion", _tokenGenerator.CreateEncodedJwt(tokenRequest, _configuration))
+                new KeyValuePair<string, string>("assertion",
+                    _tokenGenerator.CreateEncodedJwt(tokenRequest, _configuration))
             });
 
             var consumerOrg = tokenRequest.ConsumerOrg ?? this._configuration.ConsumerOrg;

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # fiks-maskinporten-dotnet
 [![MIT license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/ks-no/fiks-io-client-dotnet/blob/master/LICENSE)
-[![Nuget](https://img.shields.io/nuget/v/KS.fiks.maskinporten.client.svg)](https://www.nuget.org/packages/KS.Fiks.Maskinporten.Client)
+[![NuGet](https://img.shields.io/nuget/v/KS.fiks.maskinporten.client.svg)](https://www.nuget.org/packages/KS.Fiks.Maskinporten.Client)
 [![GitHub issues](https://img.shields.io/github/issues-raw/ks-no/kryptering-dotnet.svg)](//github.com/ks-no/fiks-maskinporten-client-dotnet/issues)
 
 ## About this library
@@ -8,11 +8,11 @@ This is a .NET library for Maskinporten authentication and authorization.
 There is also a similar version available for Java [here](https://github.com/ks-no/fiks-maskinporten)
 
 ### Integrity 
-The nuget package is signed with a KS certificate in our build process, stored securely in a safe build environment.
+The NuGet package is signed with a KS certificate in our build process, stored securely in a safe build environment.
 The package assemblies are also [strong-named](https://learn.microsoft.com/en-us/dotnet/standard/assembly/strong-named).
 
 ## Installation
-Install [KS.Fiks.Maskinporten.Client](https://www.nuget.org/packages/KS.Fiks.Maskinporten.Client) nuget package in your .net project.
+Install [KS.Fiks.Maskinporten.Client](https://www.nuget.org/packages/KS.Fiks.Maskinporten.Client) NuGet package in your .NET project.
 
 ## Example
 ### Setup configuration
@@ -38,6 +38,9 @@ var maskinportenConfig = new MaskinportenClientConfiguration(
     issuer: @"issuer",  // Issuer name, heter nå Integrasjonens identifikator i selvbetjeningsløsningen til DigDir
     numberOfSecondsLeftBeforeExpire: 10, // The token will be refreshed 10 seconds before it expires
     certificate: /* virksomhetssertifikat as a X509Certificate2  */,
+    privateKey: /* use together with public key if not using certificate parameter  */,
+    publicKey: /* use together with private key if not using certificate parameter */,
+    keyIdentifier: /* optional value. Sets header kid */,
     consumerOrg: /* optional value. Sets header consumer_org */);
 ```
 
@@ -50,6 +53,9 @@ var maskinportenConfig = new MaskinportenClientConfiguration(
     issuer: @"issuer",  // Issuer name, heter nå Integrasjonens identifikator i selvbetjeningsløsningen til DigDir
     numberOfSecondsLeftBeforeExpire: 10, // The token will be refreshed 10 seconds before it expires
     certificate: /* virksomhetssertifikat as a X509Certificate2  */,
+    privateKey: /* use together with public key if not using certificate parameter  */,
+    publicKey: /* use together with private key if not using certificate parameter */,
+    keyIdentifier: /* optional value. Sets header kid */,
     consumerOrg: /* optional value. Sets header consumer_org */);
 ```
 DigDir maintains a list of [well-know endpoints and configuration](https://docs.digdir.no/maskinporten_func_wellknown.html) for the available environments


### PR DESCRIPTION
* Lagt til 'kid' som optional header value i request for å hente JWT
* Lagt til tester for med og uten 'kid'
* Oppdatert fra .NET 6 til .NET 8 og lagt til støtte for .netstandard2.1
* Fjernet NLog