### PR TITLE
Erstattet fluent assertions og bumper dependecies

### DIFF
--- a/ExampleApplication/ExampleApplication.csproj
+++ b/ExampleApplication/ExampleApplication.csproj
@@ -11,7 +11,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.3.0" />
+      <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.3.1" />
     </ItemGroup>
 
 </Project>

--- a/KS.Fiks.Maskinporten.Client.Tests/Cache/TokenCacheTests.cs
+++ b/KS.Fiks.Maskinporten.Client.Tests/Cache/TokenCacheTests.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Threading.Tasks;
-using FluentAssertions;
 using KS.Fiks.Maskinporten.Client;
+using Shouldly;
 using Xunit;
 
 namespace Ks.Fiks.Maskinporten.Client.Tests.Cache;
@@ -24,7 +24,7 @@ public class TokenCacheTests
 
         var actualValue = await sut.GetToken(new TokenRequest { Scopes = "key"}, () => Task.FromResult(expectedValue)).ConfigureAwait(false);
 
-        actualValue.Should().Be(expectedValue);
+        actualValue.ShouldBe(expectedValue);
     }
 
     [Fact]
@@ -39,7 +39,7 @@ public class TokenCacheTests
         await Task.Delay(TimeSpan.FromMilliseconds(100)).ConfigureAwait(false);
         var secondValue = await sut.GetToken(new TokenRequest { Scopes = "key"}, () => Task.FromResult(otherValue)).ConfigureAwait(false);
 
-        secondValue.Should().Be(expectedValue);
+        secondValue.ShouldBe(expectedValue);
     }
 
     [Fact]
@@ -54,6 +54,6 @@ public class TokenCacheTests
         await Task.Delay(TimeSpan.FromMilliseconds(1500)).ConfigureAwait(false);
         var secondValue = await sut.GetToken(new TokenRequest { Scopes = "key"}, () => Task.FromResult(expectedValue)).ConfigureAwait(false);
 
-        secondValue.Should().Be(expectedValue);
+        secondValue.ShouldBe(expectedValue);
     }
 }

--- a/KS.Fiks.Maskinporten.Client.Tests/KS.Fiks.Maskinporten.Client.Tests.csproj
+++ b/KS.Fiks.Maskinporten.Client.Tests/KS.Fiks.Maskinporten.Client.Tests.csproj
@@ -9,10 +9,10 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="7.0.0" />
         <PackageReference Include="KS.Fiks.QA" Version="1.0.0" PrivateAssets="All" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
         <PackageReference Include="Moq" Version="4.20.72" />
+        <PackageReference Include="Shouldly" Version="4.2.1" />
         <PackageReference Include="xunit" Version="2.9.2" />
         <PackageReference Include="xunit.runner.visualstudio" Version="3.0.0">
         </PackageReference>

--- a/KS.Fiks.Maskinporten.Client.Tests/KS.Fiks.Maskinporten.Client.Tests.csproj
+++ b/KS.Fiks.Maskinporten.Client.Tests/KS.Fiks.Maskinporten.Client.Tests.csproj
@@ -13,8 +13,10 @@
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
         <PackageReference Include="Moq" Version="4.20.72" />
         <PackageReference Include="Shouldly" Version="4.2.1" />
-        <PackageReference Include="xunit" Version="2.9.2" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="3.0.0">
+        <PackageReference Include="xunit" Version="2.9.3" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
     </ItemGroup>
 

--- a/KS.Fiks.Maskinporten.Client.Tests/MaskinportenClientConfigurationFactoryTests.cs
+++ b/KS.Fiks.Maskinporten.Client.Tests/MaskinportenClientConfigurationFactoryTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using Shouldly;
 using Xunit;
 
 namespace Ks.Fiks.Maskinporten.Client.Tests
@@ -12,11 +12,10 @@ namespace Ks.Fiks.Maskinporten.Client.Tests
             const string issuer = "issuer";
             var certificate = TestHelper.Certificate;
             var maskinportenClientConfiguration = MaskinportenClientConfigurationFactory.CreateVer2Configuration(issuer, certificate);
-            maskinportenClientConfiguration.TokenEndpoint.Should()
-                .Be(MaskinportenClientConfigurationFactory.VER2_TOKEN_ENDPOINT);
-            maskinportenClientConfiguration.Audience.Should().Be(MaskinportenClientConfigurationFactory.VER2_AUDIENCE);
-            maskinportenClientConfiguration.Issuer.Should().Be(issuer);
-            maskinportenClientConfiguration.Certificate.Should().Be(certificate);
+            maskinportenClientConfiguration.TokenEndpoint.ShouldBe(MaskinportenClientConfigurationFactory.VER2_TOKEN_ENDPOINT);
+            maskinportenClientConfiguration.Audience.ShouldBe(MaskinportenClientConfigurationFactory.VER2_AUDIENCE);
+            maskinportenClientConfiguration.Issuer.ShouldBe(issuer);
+            maskinportenClientConfiguration.Certificate.ShouldBe(certificate);
 #pragma warning restore CS0618 // Type or member is obsolete
         }
 
@@ -26,11 +25,10 @@ namespace Ks.Fiks.Maskinporten.Client.Tests
             const string issuer = "issuer";
             var certificate = TestHelper.Certificate;
             var maskinportenClientConfiguration = MaskinportenClientConfigurationFactory.CreateTestConfiguration(issuer, certificate);
-            maskinportenClientConfiguration.TokenEndpoint.Should()
-                .Be(MaskinportenClientConfigurationFactory.TEST_TOKEN_ENDPOINT);
-            maskinportenClientConfiguration.Audience.Should().Be(MaskinportenClientConfigurationFactory.TEST_AUDIENCE);
-            maskinportenClientConfiguration.Issuer.Should().Be(issuer);
-            maskinportenClientConfiguration.Certificate.Should().Be(certificate);
+            maskinportenClientConfiguration.TokenEndpoint.ShouldBe(MaskinportenClientConfigurationFactory.TEST_TOKEN_ENDPOINT);
+            maskinportenClientConfiguration.Audience.ShouldBe(MaskinportenClientConfigurationFactory.TEST_AUDIENCE);
+            maskinportenClientConfiguration.Issuer.ShouldBe(issuer);
+            maskinportenClientConfiguration.Certificate.ShouldBe(certificate);
         }
         
         [Fact]
@@ -45,13 +43,12 @@ namespace Ks.Fiks.Maskinporten.Client.Tests
                 privateKey: privateKey,
                 publicKey: publicKey,
                 keyIdentifier: keyIdentifier);
-            maskinportenClientConfiguration.TokenEndpoint.Should()
-                .Be(MaskinportenClientConfigurationFactory.TEST_TOKEN_ENDPOINT);
-            maskinportenClientConfiguration.Audience.Should().Be(MaskinportenClientConfigurationFactory.TEST_AUDIENCE);
-            maskinportenClientConfiguration.Issuer.Should().Be(issuer);
-            maskinportenClientConfiguration.PrivateKey.Should().BeEquivalentTo(privateKey);
-            maskinportenClientConfiguration.PublicKey.Should().BeEquivalentTo(publicKey);
-            maskinportenClientConfiguration.KeyIdentifier.Should().Be(keyIdentifier);
+            maskinportenClientConfiguration.TokenEndpoint.ShouldBe(MaskinportenClientConfigurationFactory.TEST_TOKEN_ENDPOINT);
+            maskinportenClientConfiguration.Audience.ShouldBe(MaskinportenClientConfigurationFactory.TEST_AUDIENCE);
+            maskinportenClientConfiguration.Issuer.ShouldBe(issuer);
+            maskinportenClientConfiguration.PrivateKey.ShouldBeEquivalentTo(privateKey);
+            maskinportenClientConfiguration.PublicKey.ShouldBeEquivalentTo(publicKey);
+            maskinportenClientConfiguration.KeyIdentifier.ShouldBe(keyIdentifier);
         }
 
         [Fact]
@@ -60,11 +57,10 @@ namespace Ks.Fiks.Maskinporten.Client.Tests
             const string issuer = "issuer";
             var certificate = TestHelper.Certificate;
             var maskinportenClientConfiguration = MaskinportenClientConfigurationFactory.CreateProdConfiguration(issuer, certificate);
-            maskinportenClientConfiguration.TokenEndpoint.Should()
-                .Be(MaskinportenClientConfigurationFactory.PROD_TOKEN_ENDPOINT);
-            maskinportenClientConfiguration.Audience.Should().Be(MaskinportenClientConfigurationFactory.PROD_AUDIENCE);
-            maskinportenClientConfiguration.Issuer.Should().Be(issuer);
-            maskinportenClientConfiguration.Certificate.Should().Be(certificate);
+            maskinportenClientConfiguration.TokenEndpoint.ShouldBe(MaskinportenClientConfigurationFactory.PROD_TOKEN_ENDPOINT);
+            maskinportenClientConfiguration.Audience.ShouldBe(MaskinportenClientConfigurationFactory.PROD_AUDIENCE);
+            maskinportenClientConfiguration.Issuer.ShouldBe(issuer);
+            maskinportenClientConfiguration.Certificate.ShouldBe(certificate);
         }
 
         [Fact]
@@ -79,13 +75,12 @@ namespace Ks.Fiks.Maskinporten.Client.Tests
                 privateKey: privateKey,
                 publicKey: publicKey,
                 keyIdentifier: keyIdentifier);
-            maskinportenClientConfiguration.TokenEndpoint.Should()
-                .Be(MaskinportenClientConfigurationFactory.PROD_TOKEN_ENDPOINT);
-            maskinportenClientConfiguration.Audience.Should().Be(MaskinportenClientConfigurationFactory.PROD_AUDIENCE);
-            maskinportenClientConfiguration.Issuer.Should().Be(issuer);
-            maskinportenClientConfiguration.PrivateKey.Should().BeEquivalentTo(privateKey);
-            maskinportenClientConfiguration.PublicKey.Should().BeEquivalentTo(publicKey);
-            maskinportenClientConfiguration.KeyIdentifier.Should().Be(keyIdentifier);
+            maskinportenClientConfiguration.TokenEndpoint.ShouldBe(MaskinportenClientConfigurationFactory.PROD_TOKEN_ENDPOINT);
+            maskinportenClientConfiguration.Audience.ShouldBe(MaskinportenClientConfigurationFactory.PROD_AUDIENCE);
+            maskinportenClientConfiguration.Issuer.ShouldBe(issuer);
+            maskinportenClientConfiguration.PrivateKey.ShouldBeEquivalentTo(privateKey);
+            maskinportenClientConfiguration.PublicKey.ShouldBeEquivalentTo(publicKey);
+            maskinportenClientConfiguration.KeyIdentifier.ShouldBe(keyIdentifier);
         }
     }
 }

--- a/KS.Fiks.Maskinporten.Client.Tests/MaskinportenClientTests.cs
+++ b/KS.Fiks.Maskinporten.Client.Tests/MaskinportenClientTests.cs
@@ -4,7 +4,6 @@ using System.Net;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
-using FluentAssertions;
 using JWT;
 using JWT.Algorithms;
 using JWT.Exceptions;
@@ -12,6 +11,7 @@ using JWT.Serializers;
 using KS.Fiks.Maskinporten.Client.Builder;
 using Moq;
 using Moq.Protected;
+using Shouldly;
 using Xunit;
 
 namespace Ks.Fiks.Maskinporten.Client.Tests;
@@ -26,7 +26,7 @@ public class MaskinportenClientTests
         var sut = _fixture.CreateSut();
 
         var accessToken = await sut.GetAccessToken(_fixture.DefaultScopes).ConfigureAwait(false);
-        accessToken.Should().BeOfType<MaskinportenToken>();
+        accessToken.ShouldBeOfType<MaskinportenToken>();
     }
 
     [Fact]
@@ -39,7 +39,7 @@ public class MaskinportenClientTests
             .CreateSut();
 
         var accessToken = await sut.GetAccessToken(_fixture.DefaultScopes).ConfigureAwait(false);
-        accessToken.Should().BeOfType<MaskinportenToken>();
+        accessToken.ShouldBeOfType<MaskinportenToken>();
 
         // This verifies that the audience field is encrypted by the sut av possible to decrypt using key pair.
         _fixture.HttpMessageHandleMock.Protected().Verify(
@@ -99,7 +99,7 @@ public class MaskinportenClientTests
 
         var accessToken = await sut.GetAccessToken(_fixture.DefaultScopes).ConfigureAwait(false);
 
-        accessToken.Token.Should().NotBeEmpty();
+        accessToken.Token.ShouldNotBeEmpty();
     }
 
     [Fact]
@@ -128,7 +128,7 @@ public class MaskinportenClientTests
         await Task.Delay(TimeSpan.FromMilliseconds(100)).ConfigureAwait(false);
         var token2 = await sut.GetAccessToken(_fixture.DefaultScopes).ConfigureAwait(false);
 
-        token1.Should().Be(token2);
+        token1.ShouldBe(token2);
         _fixture.HttpMessageHandleMock.Protected().Verify(
             "SendAsync",
             Times.Exactly(1),
@@ -146,7 +146,7 @@ public class MaskinportenClientTests
         await Task.Delay(TimeSpan.FromMilliseconds(100)).ConfigureAwait(false);
         var token2 = await sut.GetDelegatedAccessToken(consumerOrg, _fixture.DefaultScopes).ConfigureAwait(false);
 
-        token1.Should().Be(token2);
+        token1.ShouldBe(token2);
         _fixture.HttpMessageHandleMock.Protected().Verify(
             "SendAsync",
             Times.Exactly(1),
@@ -166,7 +166,7 @@ public class MaskinportenClientTests
         var requestMessage =
             _fixture.HttpMessageHandleMock.Invocations.Single().Arguments.Single(o => o is HttpRequestMessage) as
                 HttpRequestMessage;
-        requestMessage?.Content.Should().NotBeNull();
+        requestMessage?.Content.ShouldNotBeNull();
 
         var requestContent = await requestMessage!.Content!.ReadAsStringAsync().ConfigureAwait(false);
         var contentDict = requestContent.Split("&").Select(p => p.Split("=")).ToDictionary(_ => _[0], _ => _[1]);
@@ -176,7 +176,7 @@ public class MaskinportenClientTests
             new JwtBase64UrlEncoder());
 
         var assertionData = decoder.DecodeToObject(contentDict["assertion"], false);
-        assertionData["resource"].Should().Be(audience);
+        assertionData["resource"].ShouldBe(audience);
     }
 
     [Fact]
@@ -188,7 +188,7 @@ public class MaskinportenClientTests
         await Task.Delay(TimeSpan.FromMilliseconds(1100)).ConfigureAwait(false);
         var token2 = await sut.GetAccessToken(_fixture.DefaultScopes).ConfigureAwait(false);
 
-        token1.Should().Be(token2);
+        token1.ShouldBe(token2);
         _fixture.HttpMessageHandleMock.Protected().Verify(
             "SendAsync",
             Times.Exactly(2),
@@ -205,7 +205,7 @@ public class MaskinportenClientTests
         await Task.Delay(TimeSpan.FromMilliseconds(100)).ConfigureAwait(false);
         var token2 = await sut.GetAccessToken(_fixture.DefaultScopes).ConfigureAwait(false);
 
-        token1.Should().Be(token2);
+        token1.ShouldBe(token2);
         _fixture.HttpMessageHandleMock.Protected().Verify(
             "SendAsync",
             Times.Exactly(1),
@@ -222,7 +222,7 @@ public class MaskinportenClientTests
         await Task.Delay(TimeSpan.FromMilliseconds(1100)).ConfigureAwait(false);
         var token2 = await sut.GetAccessToken(_fixture.DefaultScopes).ConfigureAwait(false);
 
-        token1.Should().Be(token2);
+        token1.ShouldBe(token2);
         _fixture.HttpMessageHandleMock.Protected().Verify(
             "SendAsync",
             Times.Exactly(2),
@@ -498,8 +498,7 @@ public class MaskinportenClientTests
         var tokenRequest = new TokenRequestBuilder().Build();
 
         var token = await sut.GetAccessToken(tokenRequest).ConfigureAwait(false);
-
-        token.Should().BeOfType<MaskinportenToken>();
+        token.ShouldBeOfType<MaskinportenToken>();
     }
 
     [Fact]
@@ -516,7 +515,7 @@ public class MaskinportenClientTests
 
         var token = await sut.GetAccessToken(tokenRequest).ConfigureAwait(false);
 
-        token.Should().BeOfType<MaskinportenToken>();
+        token.ShouldBeOfType<MaskinportenToken>();
     }
 
     [Fact]
@@ -530,10 +529,10 @@ public class MaskinportenClientTests
             .WithPid("testpid")
             .Build();
 
-        tokenRequest.Scopes.Should().Be("testscope1 testscope2");
-        tokenRequest.ConsumerOrg.Should().Be("testorg");
-        tokenRequest.OnBehalfOf.Should().Be("testonbehalfof");
-        tokenRequest.Audience.Should().Be("testaudience");
-        tokenRequest.Pid.Should().Be("testpid");
+        tokenRequest.Scopes.ShouldBe("testscope1 testscope2");
+        tokenRequest.ConsumerOrg.ShouldBe("testorg");
+        tokenRequest.OnBehalfOf.ShouldBe("testonbehalfof");
+        tokenRequest.Audience.ShouldBe("testaudience");
+        tokenRequest.Pid.ShouldBe("testpid");
     }
 }


### PR DESCRIPTION
**Dette er gjort:**
- Erstattet fluent assertions med Shoudly
- Bumps [xunit](https://github.com/xunit/xunit) from 2.9.2 to 2.9.3.
- Bumps [xunit.runner.visualstudio](https://github.com/xunit/visualstudio.xunit) from 3.0.0 to 3.0.1.
- Bumps [System.IdentityModel.Tokens.Jwt](https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet) from 8.3.0 to 8.3.1.